### PR TITLE
Pass document time to MMLWebRunnerClient. Fixes #19

### DIFF
--- a/packages/mml-web-runner/src/MMLWebRunnerClient.ts
+++ b/packages/mml-web-runner/src/MMLWebRunnerClient.ts
@@ -42,7 +42,9 @@ export class MMLWebRunnerClient extends NetworkedDOMWebRunnerClient {
       this.connectedState.domWebsocket.handleEvent(element, event);
     };
 
-    super.connect(document);
+    super.connect(document, (time: number) => {
+      remoteDocumentWrapper.setDocumentTime(time);
+    });
     this.mScene.fitContainer();
   }
 

--- a/packages/networked-dom-web-runner/src/NetworkedDOMWebRunnerClient.ts
+++ b/packages/networked-dom-web-runner/src/NetworkedDOMWebRunnerClient.ts
@@ -42,7 +42,10 @@ export class NetworkedDOMWebRunnerClient {
     this.element.remove();
   }
 
-  public connect(document: NetworkedDOM | EditableNetworkedDOM) {
+  public connect(
+    document: NetworkedDOM | EditableNetworkedDOM,
+    timeCallback?: (time: number) => void,
+  ) {
     if (this.connectedState) {
       this.disconnect();
     }
@@ -68,6 +71,7 @@ export class NetworkedDOMWebRunnerClient {
       "ws://localhost",
       () => fakeWebsocket.clientSideWebsocket as unknown as WebSocket,
       this.remoteDocumentHolder,
+      timeCallback,
     );
     overriddenHandler = (element: HTMLElement, event: CustomEvent) => {
       domWebsocket.handleEvent(element, event);


### PR DESCRIPTION
**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)

* Passes document time to the MML Web Runner's `remoteDocumentWrapper` so that elements can be kept in-sync with the document's timeline.