### PR TITLE
Cleanup m-audio debug visualisations on removal

### DIFF
--- a/packages/mml-web/src/elements/Audio.ts
+++ b/packages/mml-web/src/elements/Audio.ts
@@ -26,7 +26,6 @@ export class Audio extends TransformableElement {
     return [...TransformableElement.observedAttributes, ...Audio.attributeHandler.getAttributes()];
   }
 
-  private timer: NodeJS.Timer | null = null;
   private debugMeshes: THREE.Mesh<THREE.SphereGeometry, THREE.MeshBasicMaterial>[] = [];
 
   private loadedAudioState: {
@@ -344,6 +343,7 @@ export class Audio extends TransformableElement {
     });
 
     this.updateAudio();
+    this.updateDebugVisualisation();
   }
 
   disconnectedCallback() {

--- a/packages/mml-web/src/elements/Audio.ts
+++ b/packages/mml-web/src/elements/Audio.ts
@@ -362,6 +362,7 @@ export class Audio extends TransformableElement {
       this.delayedPauseTimer = null;
     }
     this.documentTimeListener.remove();
+    this.clearDebugVisualisation();
     super.disconnectedCallback();
   }
 


### PR DESCRIPTION
**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)

* If `debug="true"` on `m-audio` then the visualizations are added to the global scene and were not being removed. This PR removes them when the `m-audio` element is disconnected (/removed).
