### PR TITLE
Fixed handling of initial audio attributes on m-video and m-audio

### DIFF
--- a/packages/mml-web/src/elements/Audio.ts
+++ b/packages/mml-web/src/elements/Audio.ts
@@ -283,8 +283,10 @@ export class Audio extends TransformableElement {
       });
 
       const positionalAudio = new THREE.PositionalAudio(audioListener);
-
       positionalAudio.setMediaElementSource(audio);
+      positionalAudio.setVolume(this.props.volume);
+      positionalAudio.setRefDistance(this.props.refDistance);
+      positionalAudio.setRolloffFactor(this.props.rolloffFactor);
 
       this.loadedAudioState = {
         paused: false,

--- a/packages/mml-web/src/elements/Video.ts
+++ b/packages/mml-web/src/elements/Video.ts
@@ -312,6 +312,9 @@ export class Video extends TransformableElement {
 
       const audio = new THREE.PositionalAudio(audioListener);
       audio.setMediaElementSource(video);
+      audio.setVolume(this.props.volume);
+      audio.setRefDistance(this.props.refDistance);
+      audio.setRolloffFactor(this.props.rolloffFactor);
       this.loadedVideoState = {
         paused: false,
         video,


### PR DESCRIPTION
**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix: Handle/use initial attribute values for `volume`, `ref-distance` and `roll-off-factor`. These were previously not applied if the attribute changed before the media loaded. 

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
