### PR TITLE
Refactored IframeWrapper to support Firefox

### DIFF
--- a/examples/mml-web-runner-example/src/index.tsx
+++ b/examples/mml-web-runner-example/src/index.tsx
@@ -31,7 +31,7 @@ const startingContent = `
 function createCloseableClient(
   clientsHolder: HTMLElement,
   windowTarget: Window,
-  remoteHolderElement: HTMLElement,
+  iframeBody: HTMLElement,
   networkedDOMDocument: NetworkedDOM | EditableNetworkedDOM,
 ) {
   const wrapperElement = document.createElement("div");
@@ -48,20 +48,17 @@ function createCloseableClient(
     wrapperElement.remove();
   });
   wrapperElement.append(closeButton);
-  const client = new MMLWebRunnerClient(windowTarget, remoteHolderElement);
+  const client = new MMLWebRunnerClient(windowTarget, iframeBody);
   wrapperElement.append(client.element);
   clientsHolder.append(wrapperElement);
   client.connect(networkedDOMDocument);
   return client;
 }
 
-window.addEventListener("DOMContentLoaded", () => {
-  const iframeRemoteSceneWrapper = new IframeWrapper();
-  document.body.append(iframeRemoteSceneWrapper.iframe);
+window.addEventListener("DOMContentLoaded", async () => {
+  const { iframeWindow, iframeBody } = await IframeWrapper.create();
+  registerCustomElementsToWindow(iframeWindow);
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const windowTarget = iframeRemoteSceneWrapper.iframe.contentWindow!;
-  registerCustomElementsToWindow(windowTarget);
-
   const networkedDOMDocument = new EditableNetworkedDOM(
     "http://example.com/index.html",
     IframeObservableDOMFactory,
@@ -79,7 +76,7 @@ window.addEventListener("DOMContentLoaded", () => {
   const addButton = document.createElement("button");
   addButton.textContent = "Add client";
   addButton.addEventListener("click", () => {
-    createCloseableClient(clientsHolder, windowTarget, remoteHolderElement, networkedDOMDocument);
+    createCloseableClient(clientsHolder, iframeWindow, iframeBody, networkedDOMDocument);
   });
   document.body.append(addButton);
 
@@ -87,9 +84,6 @@ window.addEventListener("DOMContentLoaded", () => {
   clientsHolder.style.display = "flex";
   document.body.append(clientsHolder);
 
-  const remoteHolderElement = windowTarget.document.body;
-
-  createCloseableClient(clientsHolder, windowTarget, remoteHolderElement, networkedDOMDocument);
-
+  createCloseableClient(clientsHolder, iframeWindow, iframeBody, networkedDOMDocument);
   networkedDOMDocument.load(textArea.value);
 });

--- a/packages/mml-web-client/src/index.ts
+++ b/packages/mml-web-client/src/index.ts
@@ -49,7 +49,7 @@ function createStatusElement() {
     return;
   }
 
-  window.addEventListener("load", () => {
+  window.addEventListener("load", async () => {
     // Make a fixed-position centered status element
     const fullScreenMScene = new FullScreenMScene();
 
@@ -68,11 +68,9 @@ function createStatusElement() {
     let windowTarget: Window;
 
     if (useIframe) {
-      const iframeRemoteSceneWrapper = new IframeWrapper();
-      document.body.append(iframeRemoteSceneWrapper.iframe);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      windowTarget = iframeRemoteSceneWrapper.iframe.contentWindow!;
-      targetForWrappers = windowTarget.document.body;
+      const { iframeWindow, iframeBody } = await IframeWrapper.create();
+      windowTarget = iframeWindow;
+      targetForWrappers = iframeBody;
     } else {
       targetForWrappers = document.body;
       windowTarget = window;


### PR DESCRIPTION
Firefox seems to present an empty document as the contents of an iframe and then replace that document when the iframe "loads" even if the iframe has no `src`. As this loading is async this means that waiting until the iframe can be populated is now async and has been wrapped in a `Promise`.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] Yes.

If yes, please describe its impact and migration path for existing applications:

Minor. Usage of the `IframeWrapper` class changes substantially. The function signature has been overhauled so any type-checked usage of this new version should catch this.

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
