### PR TITLE
Removed ref-distance and roll-off from m-audio and m-video

### DIFF
--- a/packages/mml-web/src/elements/Video.ts
+++ b/packages/mml-web/src/elements/Video.ts
@@ -8,12 +8,13 @@ import {
 } from "../utils/attribute-handling";
 import { CollideableHelper } from "../utils/CollideableHelper";
 
+const audioRefDistance = 1;
+const audioRolloffFactor = 1;
+
 const disabledVideoMaterial = new THREE.MeshStandardMaterial({ color: 0x000000 });
 const defaultVideoWidth = null;
 const defaultVideoHeight = null;
 const defaultVideoVolume = 1;
-const defaultVideoRefDistance = 1;
-const defaultVideoRolloffFactor = 1;
 const defaultVideoLoop = true;
 const defaultVideoEnabled = true;
 const defaultVideoStartTime = 0;
@@ -57,8 +58,6 @@ export class Video extends TransformableElement {
     loop: defaultVideoLoop,
     enabled: defaultVideoEnabled,
     volume: defaultVideoVolume,
-    refDistance: defaultVideoRefDistance,
-    rolloffFactor: defaultVideoRolloffFactor,
     width: defaultVideoWidth as number | null,
     height: defaultVideoHeight as number | null,
   };
@@ -100,18 +99,6 @@ export class Video extends TransformableElement {
       instance.props.volume = parseFloatAttribute(newValue, defaultVideoVolume);
       if (instance.loadedVideoState) {
         instance.loadedVideoState?.audio.setVolume(instance.props.volume);
-      }
-    },
-    "ref-distance": (instance, newValue) => {
-      instance.props.refDistance = parseFloatAttribute(newValue, defaultVideoRefDistance);
-      if (instance.loadedVideoState) {
-        instance.loadedVideoState?.audio.setRefDistance(instance.props.refDistance);
-      }
-    },
-    "roll-off": (instance, newValue) => {
-      instance.props.rolloffFactor = parseFloatAttribute(newValue, defaultVideoRolloffFactor);
-      if (instance.loadedVideoState) {
-        instance.loadedVideoState?.audio.setRefDistance(instance.props.rolloffFactor);
       }
     },
     "cast-shadows": (instance, newValue) => {
@@ -313,8 +300,8 @@ export class Video extends TransformableElement {
       const audio = new THREE.PositionalAudio(audioListener);
       audio.setMediaElementSource(video);
       audio.setVolume(this.props.volume);
-      audio.setRefDistance(this.props.refDistance);
-      audio.setRolloffFactor(this.props.rolloffFactor);
+      audio.setRefDistance(audioRefDistance);
+      audio.setRolloffFactor(audioRolloffFactor);
       this.loadedVideoState = {
         paused: false,
         video,

--- a/packages/schema-validator/test/elements/m-audio.test.ts
+++ b/packages/schema-validator/test/elements/m-audio.test.ts
@@ -19,8 +19,6 @@ test("<m-audio>", () => {
   loop="true"
   enabled="true"
   volume="1.5"
-  ref-distance="1.23"
-  roll-off="5.0"
 ></m-audio>
 `);
   expect(validationErrors).toBeNull();

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -745,20 +745,6 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="roll-off" type="xs:float">
-            <xs:annotation>
-              <xs:documentation>
-                The rate at which the audio volume decreases as the listener moves away from the source. Default value is 1.
-              </xs:documentation>
-            </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="ref-distance" type="xs:float">
-            <xs:annotation>
-              <xs:documentation>
-                The reference distance in meters at which the audio volume is unaffected by the listener's distance from the source. Default value is 1 meter.
-              </xs:documentation>
-            </xs:annotation>
-          </xs:attribute>
           <xs:attribute name="start-time" type="xs:int">
             <xs:annotation>
               <xs:documentation>
@@ -871,20 +857,6 @@
             <xs:annotation>
               <xs:documentation>
                 The volume of the video's audio, ranging from 0 (silent) to 1 (maximum volume). Default value is 1.
-              </xs:documentation>
-            </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="roll-off" type="xs:float">
-            <xs:annotation>
-              <xs:documentation>
-                The rate at which the video's audio volume decreases as the listener moves away from the source. Default value is 1.
-              </xs:documentation>
-            </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="ref-distance" type="xs:float">
-            <xs:annotation>
-              <xs:documentation>
-                The reference distance in meters at which the video's audio volume is unaffected by the listener's distance from the source. Default value is 1 meter.
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>


### PR DESCRIPTION
Remove `roll-off` and `ref-distance` attributes from `m-audio` and `m-video` elements as these effects should be physically-based.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Other, please describe: Cleanup

**Does your PR introduce a breaking change?** (check one)

- [x] Yes

If yes, please describe its impact and migration path for existing applications:

* Any usage of `roll-off` or `ref-distance` attributes will be ignored by MML clients that include this change. There should be no other side-effect other than audible distances and volumes.

**Does your PR fulfill the following requirements?**

- [x] All tests are passing