### PR TITLE
Fix #31 by correcting visibility check to the remapped node id

### DIFF
--- a/packages/networked-dom-document/src/NetworkedDOM.ts
+++ b/packages/networked-dom-document/src/NetworkedDOM.ts
@@ -576,11 +576,6 @@ export class NetworkedDOM {
       return;
     }
 
-    const remappedNode = this.clientNodeIdToInternalNodeId.get(remoteEvent.nodeId);
-    if (remappedNode) {
-      remoteEvent.nodeId = remappedNode;
-    }
-
     const visibleNodes = this.visibleNodeIdsByConnectionId.get(connectionId);
     if (!visibleNodes) {
       console.error("No visible nodes for connection: " + connectionId);
@@ -591,6 +586,11 @@ export class NetworkedDOM {
       // TODO - do a pass through the hierarchy to determine if this node should be visible to this connection id to prevent clients submitting events for nodes they can't (currently) see
       console.error("Node not visible for connection: " + remoteEvent.nodeId);
       return;
+    }
+
+    const remappedNode = this.clientNodeIdToInternalNodeId.get(remoteEvent.nodeId);
+    if (remappedNode) {
+      remoteEvent.nodeId = remappedNode;
     }
 
     this.observableDom.dispatchRemoteEventFromConnectionId(connectionId, remoteEvent);


### PR DESCRIPTION
The root cause of #31 is that the id sent by the user is the remapped node id and not the internal id used by the document instance itself. 

This remapping occurs because when a document is reloaded with new source code the diffing process that allows the client to retain most of the state it has means remapping from the node ids the new document assigned itself to the node ids that the same elements had in the previous state.

The bug is caused by the client sending the external node id, and the tracking of the visibility recording the external node id, but the event handling code doing the remapping to the internal node id before checking if the element is visible and therefore not finding the correct node id in the visibility tracking.

The fix is to move the visibility check to before the remapping.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
