### PR TITLE
Use node-fetch for compatibility with node v16

### DIFF
--- a/e2e-tests/src/fetch-test.html
+++ b/e2e-tests/src/fetch-test.html
@@ -4,6 +4,20 @@
 <m-label id="json-content" content="loading" y="4.5" font-size="50" width="10" alignment="center" height="1" color="#dddddd"></m-label>
 
 <script>
+
+  if (!Request) {
+    throw new Error("fetch's Request class is not defined.");
+  }
+  if (!Response) {
+    throw new Error("fetch's Response class is not defined.");
+  }
+  if (!Headers) {
+    throw new Error("fetch's Headers class is not defined.");
+  }
+  if (!fetch) {
+    throw new Error("fetch is not defined.");
+  }
+
   const contentLabel = document.getElementById("json-content");
   async function fetchData() {
     const address = `http://localhost:8079/assets/some-data.json`;

--- a/e2e-tests/test/fetch.test.ts
+++ b/e2e-tests/test/fetch.test.ts
@@ -1,5 +1,3 @@
-import { takeAndCompareScreenshot } from "./testing-utils";
-
 describe("fetch", () => {
   test("fetch-ed content", async () => {
     const page = await globalThis.__BROWSER_GLOBAL__.newPage();

--- a/package-lock.json
+++ b/package-lock.json
@@ -3663,6 +3663,7 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
       "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -3672,6 +3673,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3767,7 +3769,8 @@
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
-      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
     },
     "node_modules/@types/webxr": {
       "version": "0.5.2",
@@ -19199,10 +19202,12 @@
       "version": "0.1.1",
       "dependencies": {
         "@mml-io/observable-dom-common": "^0.1.0",
-        "@types/jsdom": "21.1.1",
-        "@types/node-fetch": "^2.6.4",
         "jsdom": "22.1.0",
         "node-fetch": "2.6.11"
+      },
+      "devDependencies": {
+        "@types/jsdom": "21.1.1",
+        "@types/node-fetch": "^2.6.4"
       }
     },
     "packages/observable-dom-common": {
@@ -19216,6 +19221,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.1.tgz",
       "integrity": "sha512-cZFuoVLtzKP3gmq9eNosUL1R50U+USkbLtUQ1bYVgl/lKp0FZM7Cq4aIHAL8oIvQ17uSHi7jXPtfDOdjPwBE7A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3659,6 +3659,28 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
       "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -19178,7 +19200,9 @@
       "dependencies": {
         "@mml-io/observable-dom-common": "^0.1.0",
         "@types/jsdom": "21.1.1",
-        "jsdom": "22.1.0"
+        "@types/node-fetch": "^2.6.4",
+        "jsdom": "22.1.0",
+        "node-fetch": "2.6.11"
       }
     },
     "packages/observable-dom-common": {
@@ -19261,6 +19285,44 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "packages/observable-dom/node_modules/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "packages/observable-dom/node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "packages/observable-dom/node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "packages/observable-dom/node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "packages/observable-dom/node_modules/tr46": {

--- a/packages/observable-dom/package.json
+++ b/packages/observable-dom/package.json
@@ -17,9 +17,11 @@
   },
   "dependencies": {
     "@mml-io/observable-dom-common": "^0.1.0",
-    "@types/jsdom": "21.1.1",
     "jsdom": "22.1.0",
-    "node-fetch": "2.6.11",
+    "node-fetch": "2.6.11"
+  },
+  "devDependencies": {
+    "@types/jsdom": "21.1.1",
     "@types/node-fetch": "^2.6.4"
   }
 }

--- a/packages/observable-dom/package.json
+++ b/packages/observable-dom/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@mml-io/observable-dom-common": "^0.1.0",
     "@types/jsdom": "21.1.1",
-    "jsdom": "22.1.0"
+    "jsdom": "22.1.0",
+    "node-fetch": "2.6.11",
+    "@types/node-fetch": "^2.6.4"
   }
 }

--- a/packages/observable-dom/src/JSDOMRunner.ts
+++ b/packages/observable-dom/src/JSDOMRunner.ts
@@ -3,6 +3,7 @@ import vm from "vm";
 import { LogMessage, RemoteEvent } from "@mml-io/observable-dom-common";
 import { AbortablePromise, DOMWindow, JSDOM, ResourceLoader, VirtualConsole } from "jsdom";
 import * as nodeFetch from "node-fetch";
+import nodeFetchFn from "node-fetch";
 
 import { DOMRunnerFactory, DOMRunnerInterface, DOMRunnerMessage } from "./ObservableDom";
 
@@ -111,7 +112,7 @@ export class JSDOMRunner {
       beforeParse: (window) => {
         this.domWindow = window;
 
-        this.domWindow.fetch = nodeFetch as unknown as typeof fetch;
+        this.domWindow.fetch = nodeFetchFn as unknown as typeof fetch;
         this.domWindow.Headers = nodeFetch.Headers as unknown as typeof Headers;
         this.domWindow.Request = nodeFetch.Request as unknown as typeof Request;
         this.domWindow.Response = nodeFetch.Response as unknown as typeof Response;

--- a/packages/observable-dom/src/JSDOMRunner.ts
+++ b/packages/observable-dom/src/JSDOMRunner.ts
@@ -2,6 +2,7 @@ import vm from "vm";
 
 import { LogMessage, RemoteEvent } from "@mml-io/observable-dom-common";
 import { AbortablePromise, DOMWindow, JSDOM, ResourceLoader, VirtualConsole } from "jsdom";
+import * as nodeFetch from "node-fetch";
 
 import { DOMRunnerFactory, DOMRunnerInterface, DOMRunnerMessage } from "./ObservableDom";
 
@@ -110,10 +111,10 @@ export class JSDOMRunner {
       beforeParse: (window) => {
         this.domWindow = window;
 
-        this.domWindow.fetch = fetch;
-        this.domWindow.Headers = Headers;
-        this.domWindow.Request = Request;
-        this.domWindow.Response = Response;
+        this.domWindow.fetch = nodeFetch as unknown as typeof fetch;
+        this.domWindow.Headers = nodeFetch.Headers as unknown as typeof Headers;
+        this.domWindow.Request = nodeFetch.Request as unknown as typeof Request;
+        this.domWindow.Response = nodeFetch.Response as unknown as typeof Response;
 
         // This is a polyfill for https://developer.mozilla.org/en-US/docs/Web/API/Document/timeline
         const timeline = {};


### PR DESCRIPTION
`fetch` is only introduced in Node 18 and certain environments do not support Node versions > 16 so this PR changes the fetch implementation to use the `node-fetch` package rather than depend on the Node-provided `fetch`.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Refactor

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
