### PR TITLE
Forward iframe logs and unhandled exceptions via NetworkedDOM log callback

### DIFF
--- a/packages/networked-dom-web-runner/networked-dom-web-runner-iframe/src/WebBrowserDOMRunner.ts
+++ b/packages/networked-dom-web-runner/networked-dom-web-runner-iframe/src/WebBrowserDOMRunner.ts
@@ -46,12 +46,14 @@ export class WebBrowserDOMRunner implements DOMRunnerInterface {
       callback({
         logMessage: {
           level: "system",
-          content: {
-            message,
-            type: error?.name,
-            line,
-            column,
-          },
+          content: [
+            {
+              message,
+              type: error?.name,
+              line,
+              column,
+            },
+          ],
         },
       });
       return false;

--- a/packages/networked-dom-web-runner/networked-dom-web-runner-iframe/src/WebBrowserDOMRunner.ts
+++ b/packages/networked-dom-web-runner/networked-dom-web-runner-iframe/src/WebBrowserDOMRunner.ts
@@ -26,6 +26,37 @@ export class WebBrowserDOMRunner implements DOMRunnerInterface {
     this.htmlPath = htmlPath;
     this.callback = callback;
 
+    // Forward console messages
+    for (const level of ["error", "warn", "info", "log"] as const) {
+      const defaultFn = window.console[level];
+
+      window.console[level] = (...args) => {
+        callback({
+          logMessage: {
+            level,
+            content: args,
+          },
+        });
+        defaultFn(...args);
+      };
+    }
+
+    // Forward uncaught errors
+    window.onerror = (message, source, line, column, error) => {
+      callback({
+        logMessage: {
+          level: "system",
+          content: {
+            message,
+            type: error?.name,
+            line,
+            column,
+          },
+        },
+      });
+      return false;
+    };
+
     let didSendLoad = false;
 
     this.mutationObserver = new window.MutationObserver((mutationList) => {

--- a/packages/networked-dom-web-runner/test/end-to-end.test.ts
+++ b/packages/networked-dom-web-runner/test/end-to-end.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { EditableNetworkedDOM } from "@mml-io/networked-dom-document";
+import { LogMessage } from "@mml-io/observable-dom-common";
 import { AudioContext } from "standardized-audio-context-mock";
 
 import { waitFor } from "./test-util";
@@ -12,10 +13,15 @@ beforeAll(() => {
   (window as any).AudioContext = AudioContext;
 });
 test("networked-dom-web-runner end-to-end", async () => {
+  const logs: LogMessage[] = [];
+
   const networkedDOMDocument = new EditableNetworkedDOM(
     "http://example.com/index.html",
     IframeObservableDOMFactory,
     false,
+    (logMessage) => {
+      logs.push(logMessage);
+    },
   );
 
   const clientsHolder = document.createElement("div");
@@ -26,7 +32,17 @@ test("networked-dom-web-runner end-to-end", async () => {
   client.connect(networkedDOMDocument);
 
   networkedDOMDocument.load(
-    "<div data-some-id=\"test-element\" onclick=\"this.setAttribute('data-some-attr','new-value')\"></div>",
+    `<div 
+      data-some-id="test-element" 
+      onclick="
+        this.setAttribute('data-some-attr','new-value'); 
+        console.log('level-log'); 
+        console.info('level-info'); 
+        console.warn('level-warn'); 
+        console.error('level-error'); 
+        undef[1];
+      "
+    ></div>`,
   );
 
   await waitFor(() => {
@@ -36,6 +52,46 @@ test("networked-dom-web-runner end-to-end", async () => {
 
   testElement.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   await waitFor(() => testElement.getAttribute("data-some-attr") === "new-value");
+
+  await waitFor(() => true);
+
+  expect(logs).toContainEqual(
+    expect.objectContaining({
+      level: "log",
+      content: ["level-log"],
+    }),
+  );
+
+  expect(logs).toContainEqual(
+    expect.objectContaining({
+      level: "info",
+      content: ["level-info"],
+    }),
+  );
+
+  expect(logs).toContainEqual(
+    expect.objectContaining({
+      level: "warn",
+      content: ["level-warn"],
+    }),
+  );
+
+  expect(logs).toContainEqual(
+    expect.objectContaining({
+      level: "error",
+      content: ["level-error"],
+    }),
+  );
+
+  expect(logs).toContainEqual(
+    expect.objectContaining({
+      level: "system",
+      content: expect.objectContaining({
+        message: "undef is not defined",
+        type: "ReferenceError",
+      }),
+    }),
+  );
 
   networkedDOMDocument.dispose();
 });

--- a/packages/networked-dom-web-runner/test/end-to-end.test.ts
+++ b/packages/networked-dom-web-runner/test/end-to-end.test.ts
@@ -86,10 +86,12 @@ test("networked-dom-web-runner end-to-end", async () => {
   expect(logs).toContainEqual(
     expect.objectContaining({
       level: "system",
-      content: expect.objectContaining({
-        message: "undef is not defined",
-        type: "ReferenceError",
-      }),
+      content: [
+        expect.objectContaining({
+          message: "undef is not defined",
+          type: "ReferenceError",
+        }),
+      ],
     }),
   );
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Before submitting, please review the contributor guidelines: https://github.com/mml-io/mml/blob/main/CONTRIBUTING.md.
-->

The `WebBrowserDOMRunner` has been extended to override the default implementations of console functions, e.g. `console.log(...)`, with custom ones that pass the logged args to the `NetworkedDOM` log message callback. The `window.onerror` callback has also been added to capture any uncaught exceptions and forward corresponding messages via the same `NetworkedDOM` callback. 

This changes this PR introduces allow for external observation of logs and errors occurring within the locally executing MML document.

---

**What kind of changes does your PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [x] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfil the following requirements?**

- [x] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
