### PR TITLE
Handle errors when attempting to create invalid elements

### DIFF
--- a/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
+++ b/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
@@ -422,7 +422,13 @@ export class NetworkedDOMWebsocket {
       return textNode;
     }
 
-    const element = document.createElement(tag);
+    let element;
+    try {
+      element = document.createElement(tag);
+    } catch (e) {
+      console.error(`Error creating element: (${tag})`, e);
+      element = document.createElement("div");
+    }
     this.idToElement.set(nodeId, element);
     this.elementToId.set(element, nodeId);
     for (const key in attributes) {


### PR DESCRIPTION
This PR catches errors when attempting to create invalid element names (e.g. `M-<M-GROUP` that you can get by writing `<m-<m-group` into a document.)

The behaviour is then to add a non-behavioural element and continue.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
