### PR TITLE
Fixed class instance usage of isHTMLElement

### DIFF
--- a/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
+++ b/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
@@ -25,26 +25,6 @@ export enum NetworkedDOMWebsocketStatus {
   Disconnected,
 }
 
-function isHTMLElement(node: unknown): node is HTMLElement {
-  if (node instanceof HTMLElement) {
-    return true;
-  }
-  if (!this.parentElement.ownerDocument.defaultView) {
-    return false;
-  }
-  return node instanceof this.parentElement.ownerDocument.defaultView.HTMLElement;
-}
-
-function isText(node: unknown): node is Text {
-  if (node instanceof Text) {
-    return true;
-  }
-  if (!this.parentElement.ownerDocument.defaultView) {
-    return false;
-  }
-  return node instanceof this.parentElement.ownerDocument.defaultView.Text;
-}
-
 export class NetworkedDOMWebsocket {
   private idToElement = new Map<number, Node>();
   private elementToId = new Map<Node, number>();
@@ -86,6 +66,26 @@ export class NetworkedDOMWebsocket {
       });
     this.setStatus(NetworkedDOMWebsocketStatus.Connecting);
     this.startWebSocketConnectionAttempt();
+  }
+
+  private isHTMLElement(node: unknown): node is HTMLElement {
+    if (node instanceof HTMLElement) {
+      return true;
+    }
+    if (!this.parentElement.ownerDocument.defaultView) {
+      return false;
+    }
+    return node instanceof this.parentElement.ownerDocument.defaultView.HTMLElement;
+  }
+
+  private isText(node: unknown): node is Text {
+    if (node instanceof Text) {
+      return true;
+    }
+    if (!this.parentElement.ownerDocument.defaultView) {
+      return false;
+    }
+    return node instanceof this.parentElement.ownerDocument.defaultView.Text;
   }
 
   private setStatus(status: NetworkedDOMWebsocketStatus) {
@@ -219,7 +219,7 @@ export class NetworkedDOMWebsocket {
           if (!element) {
             throw new Error("Snapshot element not created");
           }
-          if (!isHTMLElement(element)) {
+          if (!this.isHTMLElement(element)) {
             throw new Error("Snapshot element is not an HTMLElement");
           }
           this.currentRoot = element;
@@ -295,7 +295,7 @@ export class NetworkedDOMWebsocket {
     if (!node) {
       throw new Error("No node found for textChanged message");
     }
-    if (!isText(node)) {
+    if (!this.isText(node)) {
       throw new Error("Node for textChanged message is not a Text node");
     }
     node.textContent = text;
@@ -314,7 +314,7 @@ export class NetworkedDOMWebsocket {
     if (!parent.isConnected) {
       console.error("Parent is not connected", parent);
     }
-    if (!isHTMLElement(parent)) {
+    if (!this.isHTMLElement(parent)) {
       throw new Error("Parent is not an HTMLElement (that supports children)");
     }
     let previousElement;
@@ -348,7 +348,7 @@ export class NetworkedDOMWebsocket {
       this.elementToId.delete(childElement);
       this.idToElement.delete(removedNode);
       parent.removeChild(childElement);
-      if (isHTMLElement(childElement)) {
+      if (this.isHTMLElement(childElement)) {
         // If child is capable of supporting children then remove any that exist
         this.removeChildElementIds(childElement);
       }
@@ -377,7 +377,7 @@ export class NetworkedDOMWebsocket {
     }
     const element = this.idToElement.get(nodeId);
     if (element) {
-      if (isHTMLElement(element)) {
+      if (this.isHTMLElement(element)) {
         if (newValue === null) {
           element.removeAttribute(attribute);
         } else {


### PR DESCRIPTION
* Fixes a bug where the `isHTMLElement` call was being made using `this` in a non-class instance scope

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
