### PR TITLE
Made collide="true" the default

### DIFF
--- a/packages/mml-web/src/utils/CollideableHelper.ts
+++ b/packages/mml-web/src/utils/CollideableHelper.ts
@@ -7,7 +7,7 @@ import { IMMLScene } from "../MMLScene";
 
 const collideAttributeName = "collide";
 const debugAttributeName = "debug";
-const defaultCollideable = false;
+const defaultCollideable = true;
 const defaultDebug = false;
 
 export class CollideableHelper {
@@ -15,7 +15,7 @@ export class CollideableHelper {
   private element: MElement;
 
   private props = {
-    collide: false,
+    collide: defaultCollideable,
     debug: false,
   };
 

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -206,7 +206,7 @@
     <xs:attribute name="collide" type="xs:boolean">
       <xs:annotation>
         <xs:documentation>
-          Whether or not this object should participate in collision detection by other systems. Default value is false. If set to true, the object will be considered for collision tests.
+          Whether or not this object should participate in collision detection by other systems. Default value is true. If set to true, the object will be considered for collision tests.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>


### PR DESCRIPTION
This PR changes `collide` from default `false` to default `true`

Whilst technically a breaking change, the known usages of the web library (e.g. https://github.com/mml-io/mml-playground) don't yet implement collisions so it's expected that this change will not affect creations that have targeted this environment.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Other, please describe: Changed default behaviour

**Does your PR introduce a breaking change?** (check one)

- [x] ~Yes (see above)

If yes, please describe its impact and migration path for existing applications:

If a document is written that assumes `collide` defaults to `false` and it is intended that certain elements are not collideable then that document will have to be changed to explicitly set `collide="false"` for those elements.

**Does your PR fulfill the following requirements?**

- [x] All tests are passing

