### PR TITLE
Changed local ports from 8000 range to 7000 range

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ This repo contains libraries and schema definitions for MML. The most likely way
 1. `npm install`
 1. `npm run iterate` Builds and starts incrementally building package artefacts from sources
    * Servers should start for examples:
-     * [http://localhost:8080](http://localhost:8080) - MML Example Server
-     * [http://localhost:8081](http://localhost:8081) - Networked DOM Example Server
+     * [http://localhost:7070](http://localhost:7070) - MML Example Server
+     * [http://localhost:7071](http://localhost:7071) - Networked DOM Example Server
 
 To use any of the libraries in this repo in another project, you can use `npm link` to make these dependencies linkable to your other npm project.
 * `npm run link-all` Runs `npm link` in all would-be-published packages to allow using as local dependencies to develop with. It will also print the commands to link the dependencies.

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -8,7 +8,7 @@
     "serve": "node --enable-source-maps ./build/index.js",
     "ci:e2e-tests": "npm run wait-for-ports && HEADLESS=true jest --runInBand",
     "e2e-tests": "npm run wait-for-ports && HEADLESS=false jest --runInBand",
-    "wait-for-ports": "npx wait-on http://127.0.0.1:8079 -t 60000 && npx wait-on http://127.0.0.1:28891 -t 60000"
+    "wait-for-ports": "npx wait-on http://127.0.0.1:7079 -t 60000 && npx wait-on http://127.0.0.1:28891 -t 60000"
   },
   "dependencies": {
     "chokidar": "3.5.3",

--- a/e2e-tests/src/fetch-test.html
+++ b/e2e-tests/src/fetch-test.html
@@ -20,7 +20,7 @@
 
   const contentLabel = document.getElementById("json-content");
   async function fetchData() {
-    const address = `http://localhost:8079/assets/some-data.json`;
+    const address = `http://localhost:7079/assets/some-data.json`;
     const res = await fetch(address);
     const json = await res.json();
     contentLabel.setAttribute("content", `${JSON.stringify(json)}`);

--- a/e2e-tests/src/index.ts
+++ b/e2e-tests/src/index.ts
@@ -7,7 +7,7 @@ import * as chokidar from "chokidar";
 import express, { Request } from "express";
 import enableWs from "express-ws";
 
-const port = process.env.PORT || 8079;
+const port = process.env.PORT || 7079;
 
 const srcPath = path.resolve(__dirname, "../src");
 

--- a/e2e-tests/test/fetch.test.ts
+++ b/e2e-tests/test/fetch.test.ts
@@ -4,7 +4,7 @@ describe("fetch", () => {
 
     await page.setViewport({ width: 1024, height: 1024 });
 
-    await page.goto("http://localhost:8079/fetch-test.html/reset");
+    await page.goto("http://localhost:7079/fetch-test.html/reset");
 
     const textSelector = await page.waitForSelector("m-label");
     const fullTitle = await textSelector?.evaluate((el) => el.getAttribute("content"));

--- a/e2e-tests/test/m-character-anim-pause.test.ts
+++ b/e2e-tests/test/m-character-anim-pause.test.ts
@@ -8,7 +8,7 @@ describe("m-character", () => {
 
     await page.setViewport({ width: 1024, height: 1024 });
 
-    await page.goto("http://localhost:8079/m-character-anim-pause-test.html/reset");
+    await page.goto("http://localhost:7079/m-character-anim-pause-test.html/reset");
 
     await page.waitForSelector("m-character");
 

--- a/e2e-tests/test/m-cube-click.test.ts
+++ b/e2e-tests/test/m-cube-click.test.ts
@@ -6,7 +6,7 @@ describe("m-cube", () => {
 
     await page.setViewport({ width: 1024, height: 1024 });
 
-    await page.goto("http://localhost:8079/m-cube-test.html/reset");
+    await page.goto("http://localhost:7079/m-cube-test.html/reset");
 
     await page.waitForSelector("m-cube[color='red']");
 

--- a/e2e-tests/test/m-frame-static.test.ts
+++ b/e2e-tests/test/m-frame-static.test.ts
@@ -6,7 +6,7 @@ describe("m-frame", () => {
 
     await page.setViewport({ width: 1024, height: 1024 });
 
-    await page.goto("http://localhost:8079/m-frame-static-test.html/reset");
+    await page.goto("http://localhost:7079/m-frame-static-test.html/reset");
 
     await page.waitForSelector("m-frame");
 

--- a/e2e-tests/test/m-interaction-click.test.ts
+++ b/e2e-tests/test/m-interaction-click.test.ts
@@ -8,7 +8,7 @@ describe("m-interaction", () => {
 
     await page.setViewport({ width: 1024, height: 1024 });
 
-    await page.goto("http://localhost:8079/m-interaction-test.html/reset");
+    await page.goto("http://localhost:7079/m-interaction-test.html/reset");
 
     await page.waitForSelector("m-plane[color='yellow']");
 

--- a/e2e-tests/test/m-model-anim-pause.test.ts
+++ b/e2e-tests/test/m-model-anim-pause.test.ts
@@ -8,7 +8,7 @@ describe("m-model", () => {
 
     await page.setViewport({ width: 1024, height: 1024 });
 
-    await page.goto("http://localhost:8079/m-model-anim-pause-test.html/reset");
+    await page.goto("http://localhost:7079/m-model-anim-pause-test.html/reset");
 
     await page.waitForSelector("m-model");
 

--- a/e2e-tests/test/m-position-probe.test.ts
+++ b/e2e-tests/test/m-position-probe.test.ts
@@ -8,7 +8,7 @@ describe("m-position-probe", () => {
 
     await page.setViewport({ width: 1024, height: 1024 });
 
-    await page.goto("http://localhost:8079/m-position-probe-test.html/reset");
+    await page.goto("http://localhost:7079/m-position-probe-test.html/reset");
 
     await page.waitForSelector("m-position-probe");
 

--- a/e2e-tests/test/m-prompt.test.ts
+++ b/e2e-tests/test/m-prompt.test.ts
@@ -8,7 +8,7 @@ describe("m-prompt", () => {
 
     await page.setViewport({ width: 1024, height: 1024 });
 
-    await page.goto("http://localhost:8079/m-prompt-test.html/reset");
+    await page.goto("http://localhost:7079/m-prompt-test.html/reset");
 
     await page.waitForSelector("m-prompt");
 

--- a/examples/mml-web-client-example/src/index.ts
+++ b/examples/mml-web-client-example/src/index.ts
@@ -9,7 +9,7 @@ import enableWs from "express-ws";
 import { EditableNetworkedDOM, LocalObservableDOMFactory } from "networked-dom-server";
 import ws from "ws";
 
-const port = process.env.PORT || 8080;
+const port = process.env.PORT || 7070;
 
 const filePath = path.resolve(__dirname, "../src/mml-document.html");
 

--- a/examples/networked-dom-web-client-example/src/index.ts
+++ b/examples/networked-dom-web-client-example/src/index.ts
@@ -9,7 +9,7 @@ import express, { Request } from "express";
 import enableWs from "express-ws";
 import ws from "ws";
 
-const port = process.env.PORT || 8081;
+const port = process.env.PORT || 7071;
 
 const filePath = path.resolve(__dirname, "../src/networked-dom-document.html");
 


### PR DESCRIPTION
To avoid conflicts with other projects in this organisation and also to avoid the commonly used 8080 port this PR changes the ports in the following manner:
* `8080` -> `7070` (MML Example)
* `8081`-> `7071` (NetworkedDOM Example)
* `8079` -> `7079` (E2E test server)

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Other, please describe: Port changes

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
