### PR TITLE
Fixed NetworkedDOMBroadcastReceiver's ability to handle switching runners

### DIFF
--- a/packages/networked-dom-document/src/NetworkedDOM.ts
+++ b/packages/networked-dom-document/src/NetworkedDOM.ts
@@ -458,9 +458,6 @@ export class NetworkedDOM {
 
   public dispose(): void {
     this.disposed = true;
-    for (const [, connectionId] of this.webSocketToConnectionId) {
-      this.observableDOM.removeConnectedUserId(connectionId);
-    }
 
     // Handle all of the remaining mutations that the disconnections could have caused
     this.observableDOM.dispose();

--- a/packages/networked-dom-document/src/NetworkedDOM.ts
+++ b/packages/networked-dom-document/src/NetworkedDOM.ts
@@ -257,21 +257,21 @@ export class NetworkedDOM {
           virtualDOMDiff,
         );
 
-        const patchResults = applyPatch(domDiff.originalState, [virtualDOMDiff]);
-        for (const patchResult of patchResults) {
-          if (patchResult !== null) {
-            console.error("Patching virtual dom structure resulted in error", patchResult);
-            throw patchResult;
+        if (virtualDOMDiff.path === "" && virtualDOMDiff.op === "replace") {
+          // The patch is a snapshot replacement - no need to check the patch validity
+        } else {
+          const patchResults = applyPatch(domDiff.originalState, [virtualDOMDiff]);
+          for (const patchResult of patchResults) {
+            if (patchResult !== null) {
+              console.error("Patching virtual dom structure resulted in error", patchResult);
+              throw patchResult;
+            }
           }
         }
 
         for (const mutationRecordLike of mutationRecordLikes) {
           const targetNodeId = mutationRecordLike.target.nodeId;
           const virtualElementParent = findParentNodeOfNodeId(domDiff.originalState, targetNodeId);
-          if (!virtualElementParent) {
-            throw new Error(`could not find parent node of nodeId ${targetNodeId}`);
-          }
-
           diffsByConnectionId.forEach((diffs, connectionId) => {
             const mutationDiff = diffFromApplicationOfStaticVirtualDOMMutationRecordToConnection(
               mutationRecordLike,

--- a/packages/networked-dom-document/src/common.ts
+++ b/packages/networked-dom-document/src/common.ts
@@ -14,7 +14,7 @@ export type VirtualDOMDiffStruct = {
 
 // This is similar to the MutationRecord type in the DOM spec, but it references StaticVirtualDOMElements instead of DOM nodes.
 export type StaticVirtualDOMMutationRecord = {
-  type: "attributes" | "characterData" | "childList";
+  type: "attributes" | "characterData" | "childList" | "snapshot";
   target: StaticVirtualDOMElement;
   addedNodes: Array<StaticVirtualDOMElement>;
   removedNodes: Array<StaticVirtualDOMElement>;

--- a/packages/networked-dom-protocol/src/networked-dom-v0.1/from-server.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.1/from-server.ts
@@ -45,7 +45,7 @@ export type AttributeChangedDiff = {
   documentTime?: number;
 };
 
-export type Diff = ChildrenChangedDiff | AttributeChangedDiff | TextChangedDiff;
+export type Diff = SnapshotMessage | ChildrenChangedDiff | AttributeChangedDiff | TextChangedDiff;
 
 export type PingMessage = {
   type: "ping";
@@ -63,4 +63,4 @@ export type WarningMessage = {
   message: string;
 };
 
-export type ServerMessage = SnapshotMessage | Diff | PingMessage | ErrorMessage | WarningMessage;
+export type ServerMessage = Diff | PingMessage | ErrorMessage | WarningMessage;

--- a/packages/networked-dom-web-runner-broadcast/jest.config.ts
+++ b/packages/networked-dom-web-runner-broadcast/jest.config.ts
@@ -1,11 +1,11 @@
 import type { Config } from "jest";
 
 const config: Config = {
+  testEnvironment: "jsdom",
   verbose: true,
   collectCoverage: true,
   coverageDirectory: "coverage",
   coverageReporters: ["lcov", "text"],
-  testEnvironment: "node",
   setupFiles: ["jest-canvas-mock"],
   setupFilesAfterEnv: ["jest-expect-message"],
   transform: {

--- a/packages/networked-dom-web-runner-broadcast/src/NetworkedDOMBroadcastReceiver.ts
+++ b/packages/networked-dom-web-runner-broadcast/src/NetworkedDOMBroadcastReceiver.ts
@@ -77,12 +77,41 @@ export class NetworkedDOMBroadcastReceiver {
               // no-op dispose
             },
           );
+          callback(
+            {
+              snapshot: {
+                nodeId: 1,
+                tag: "div",
+                attributes: {},
+                childNodes: [],
+              },
+              documentTime: 0,
+            },
+            remoteObservableDOM,
+          );
           return remoteObservableDOM;
         }
       },
       ignoreTextNodes,
       logCallback,
     );
+  }
+
+  public clearRevisionState() {
+    /*
+     This allows reusing revision ids (e.g. from another runner)
+
+     This doesn't itself clear the EditableNetworkedDOM, which allows the revision from another runner to be diffed
+     against the previous state
+    */
+    this.currentRevisionState = null;
+  }
+
+  public clearState() {
+    this.clearRevisionState();
+
+    // Calling load with no revision state will clear the EditableNetworkedDOM to an empty state
+    this.editableNetworkedDOM.load("", {});
   }
 
   public handleMessage(parsed: FromBroadcastInstanceMessage) {

--- a/packages/networked-dom-web-runner-broadcast/src/NetworkedDOMBroadcastRunner.ts
+++ b/packages/networked-dom-web-runner-broadcast/src/NetworkedDOMBroadcastRunner.ts
@@ -59,6 +59,13 @@ export class NetworkedDOMBroadcastRunner {
     }
   }
 
+  public dispose() {
+    if (this.currentDOM !== null) {
+      this.currentDOM.dispose();
+      this.currentDOM = null;
+    }
+  }
+
   public load(observableDOMParameters: ObservableDOMParameters) {
     const revisionId = ++this.currentRevisionId;
 

--- a/packages/networked-dom-web-runner-broadcast/test/broadcast-end-to-end.test.ts
+++ b/packages/networked-dom-web-runner-broadcast/test/broadcast-end-to-end.test.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import {
   FakeWebsocket,
   IframeObservableDOMFactory,
@@ -17,104 +13,179 @@ import {
   ToBroadcastInstanceMessage,
 } from "../src";
 
-test("broadcast end-to-end", async () => {
-  const logs: LogMessage[] = [];
+describe("broadcast", function() {
+  test("end-to-end", async () => {
+    const logs: LogMessage[] = [];
 
-  const fakeWebSocket = new FakeWebsocket("");
+    const fakeWebSocket = new FakeWebsocket("");
 
-  const broadcastReceiver = new NetworkedDOMBroadcastReceiver(
-    (toBroadcastInstanceMessage: ToBroadcastInstanceMessage) => {
-      fakeWebSocket.serverSideWebsocket.send(JSON.stringify(toBroadcastInstanceMessage));
-    },
-    true,
-    (logMessage) => {
-      logs.push(logMessage);
-    },
-  );
+    const broadcastReceiver = new NetworkedDOMBroadcastReceiver(
+      (toBroadcastInstanceMessage: ToBroadcastInstanceMessage) => {
+        fakeWebSocket.serverSideWebsocket.send(JSON.stringify(toBroadcastInstanceMessage));
+      },
+      true,
+      (logMessage) => {
+        logs.push(logMessage);
+      },
+    );
 
-  fakeWebSocket.serverSideWebsocket.addEventListener("message", (message: MessageEvent) => {
-    broadcastReceiver.handleMessage(JSON.parse(message.data) as FromBroadcastInstanceMessage);
+    fakeWebSocket.serverSideWebsocket.addEventListener("message", (message: MessageEvent) => {
+      broadcastReceiver.handleMessage(JSON.parse(message.data) as FromBroadcastInstanceMessage);
+    });
+
+    const broadcastRunner = new NetworkedDOMBroadcastRunner(
+      (fromBroadcastInstanceMessage: FromBroadcastInstanceMessage) => {
+        fakeWebSocket.clientSideWebsocket.send(JSON.stringify(fromBroadcastInstanceMessage));
+      },
+      IframeObservableDOMFactory,
+    );
+
+    fakeWebSocket.clientSideWebsocket.addEventListener("message", (message: MessageEvent) => {
+      broadcastRunner.handleMessage(JSON.parse(message.data) as ToBroadcastInstanceMessage);
+    });
+
+    const clientsHolder = document.createElement("div");
+    document.body.append(clientsHolder);
+
+    const client = new NetworkedDOMWebRunnerClient();
+    clientsHolder.append(client.element);
+    client.connect(broadcastReceiver.editableNetworkedDOM);
+
+    broadcastRunner.load({
+      htmlContents: `<div 
+        id="test-element" 
+        onclick="
+          this.setAttribute('attr','new-value'); 
+          console.log('broadcast-end-to-end-test-level-log'); 
+          console.info('broadcast-end-to-end-test-level-info'); 
+          console.warn('broadcast-end-to-end-test-level-warn'); 
+          console.error('broadcast-end-to-end-test-level-error'); 
+          undef[1];
+        "
+      ></div>`,
+      htmlPath: "file://test.html",
+      ignoreTextNodes: false,
+      params: {},
+    });
+
+    await waitFor(() => {
+      return client.element.querySelectorAll("#test-element").length > 0;
+    });
+    const testElement = client.element.querySelectorAll("#test-element")[0];
+
+    testElement.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await waitFor(() => testElement.getAttribute("attr") === "new-value");
+
+    expect(logs).toEqual([
+      expect.objectContaining({
+        level: "log",
+        content: ["broadcast-end-to-end-test-level-log"],
+      }),
+      expect.objectContaining({
+        level: "info",
+        content: ["broadcast-end-to-end-test-level-info"],
+      }),
+      expect.objectContaining({
+        level: "warn",
+        content: ["broadcast-end-to-end-test-level-warn"],
+      }),
+      expect.objectContaining({
+        level: "error",
+        content: ["broadcast-end-to-end-test-level-error"],
+      }),
+      expect.objectContaining({
+        level: "system",
+        content: [
+          expect.objectContaining({
+            message: "undef is not defined",
+            type: "ReferenceError",
+          }),
+        ],
+      }),
+    ]);
+
+    broadcastRunner.load({
+      htmlContents: `<div id="different-element"></div>`,
+      htmlPath: "file://test.html",
+      ignoreTextNodes: false,
+      params: {},
+    });
+
+    await waitFor(() => {
+      return client.element.querySelectorAll("#different-element").length > 0;
+    });
+
+    broadcastReceiver.clearState();
+
+    await waitFor(() => {
+      return client.element.querySelectorAll("#different-element").length === 0;
+    });
   });
 
-  const broadcastRunner = new NetworkedDOMBroadcastRunner(
-    (fromBroadcastInstanceMessage: FromBroadcastInstanceMessage) => {
-      fakeWebSocket.clientSideWebsocket.send(JSON.stringify(fromBroadcastInstanceMessage));
-    },
-    IframeObservableDOMFactory,
-  );
+  test("replace runner", async () => {
+    const broadcastReceiver = new NetworkedDOMBroadcastReceiver(
+      (toBroadcastInstanceMessage: ToBroadcastInstanceMessage) => {
+        currentRunner.handleMessage(toBroadcastInstanceMessage);
+      },
+      true,
+      (logMessage) => {
+        console.log("logMessage", logMessage);
+      },
+    );
 
-  fakeWebSocket.clientSideWebsocket.addEventListener("message", (message: MessageEvent) => {
-    broadcastRunner.handleMessage(JSON.parse(message.data) as ToBroadcastInstanceMessage);
-  });
+    const broadcastRunnerOne = new NetworkedDOMBroadcastRunner(
+      (fromBroadcastInstanceMessage: FromBroadcastInstanceMessage) => {
+        if (currentRunner !== broadcastRunnerOne) {
+          throw new Error("currentRunner !== broadcastRunnerOne");
+        }
+        broadcastReceiver.handleMessage(fromBroadcastInstanceMessage);
+      },
+      IframeObservableDOMFactory,
+    );
+    const broadcastRunnerTwo = new NetworkedDOMBroadcastRunner(
+      (fromBroadcastInstanceMessage: FromBroadcastInstanceMessage) => {
+        if (currentRunner !== broadcastRunnerTwo) {
+          throw new Error("currentRunner !== broadcastRunnerTwo");
+        }
+        broadcastReceiver.handleMessage(fromBroadcastInstanceMessage);
+      },
+      IframeObservableDOMFactory,
+    );
+    let currentRunner = broadcastRunnerOne;
 
-  const clientsHolder = document.createElement("div");
-  document.body.append(clientsHolder);
+    const clientsHolder = document.createElement("div");
+    document.body.append(clientsHolder);
 
-  const client = new NetworkedDOMWebRunnerClient();
-  clientsHolder.append(client.element);
-  client.connect(broadcastReceiver.editableNetworkedDOM);
+    const client = new NetworkedDOMWebRunnerClient();
+    clientsHolder.append(client.element);
+    client.connect(broadcastReceiver.editableNetworkedDOM);
 
-  broadcastRunner.load({
-    htmlContents: `<div 
-      data-some-id="test-element" 
-      onclick="
-        this.setAttribute('data-some-attr','new-value'); 
-        console.log('broadcast-end-to-end-test-level-log'); 
-        console.info('broadcast-end-to-end-test-level-info'); 
-        console.warn('broadcast-end-to-end-test-level-warn'); 
-        console.error('broadcast-end-to-end-test-level-error'); 
-        undef[1];
-      "
-    ></div>`,
-    htmlPath: "file://test.html",
-    ignoreTextNodes: false,
-    params: {},
-  });
+    broadcastRunnerOne.load({
+      htmlContents: `<div id="test-element-one"></div><div id="inner-element-one"></div></div>`,
+      htmlPath: "file://test.html",
+      ignoreTextNodes: false,
+      params: {},
+    });
 
-  await waitFor(() => {
-    return client.element.querySelectorAll("[data-some-id='test-element']").length > 0;
-  });
-  const testElement = client.element.querySelectorAll("[data-some-id='test-element']")[0];
+    await waitFor(() => {
+      return client.element.querySelectorAll("#inner-element-one").length > 0;
+    });
 
-  testElement.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-  await waitFor(() => testElement.getAttribute("data-some-attr") === "new-value");
+    broadcastRunnerOne.dispose();
 
-  expect(logs).toEqual([
-    expect.objectContaining({
-      level: "log",
-      content: ["broadcast-end-to-end-test-level-log"],
-    }),
-    expect.objectContaining({
-      level: "info",
-      content: ["broadcast-end-to-end-test-level-info"],
-    }),
-    expect.objectContaining({
-      level: "warn",
-      content: ["broadcast-end-to-end-test-level-warn"],
-    }),
-    expect.objectContaining({
-      level: "error",
-      content: ["broadcast-end-to-end-test-level-error"],
-    }),
-    expect.objectContaining({
-      level: "system",
-      content: [
-        expect.objectContaining({
-          message: "undef is not defined",
-          type: "ReferenceError",
-        }),
-      ],
-    }),
-  ]);
+    broadcastReceiver.clearRevisionState();
 
-  broadcastRunner.load({
-    htmlContents: `<div data-some-id="different-element"></div>`,
-    htmlPath: "file://test.html",
-    ignoreTextNodes: false,
-    params: {},
-  });
+    currentRunner = broadcastRunnerTwo;
 
-  await waitFor(() => {
-    return client.element.querySelectorAll("[data-some-id='different-element']").length > 0;
+    broadcastRunnerTwo.load({
+      htmlContents: `<div id="test-element-two"><div id="inner-element-two"></div></div>`,
+      htmlPath: "file://test.html",
+      ignoreTextNodes: false,
+      params: {},
+    });
+
+    await waitFor(() => {
+      return client.element.querySelectorAll("#inner-element-two").length > 0;
+    });
   });
 });

--- a/packages/networked-dom-web-runner-broadcast/test/broadcast-end-to-end.test.ts
+++ b/packages/networked-dom-web-runner-broadcast/test/broadcast-end-to-end.test.ts
@@ -13,7 +13,7 @@ import {
   ToBroadcastInstanceMessage,
 } from "../src";
 
-describe("broadcast", function() {
+describe("broadcast", function () {
   test("end-to-end", async () => {
     const logs: LogMessage[] = [];
 
@@ -142,6 +142,8 @@ describe("broadcast", function() {
       },
       IframeObservableDOMFactory,
     );
+    const broadcastRunnerOneHandlerSpy = jest.spyOn(broadcastRunnerOne, "handleMessage");
+
     const broadcastRunnerTwo = new NetworkedDOMBroadcastRunner(
       (fromBroadcastInstanceMessage: FromBroadcastInstanceMessage) => {
         if (currentRunner !== broadcastRunnerTwo) {
@@ -151,6 +153,8 @@ describe("broadcast", function() {
       },
       IframeObservableDOMFactory,
     );
+    const broadcastRunnerTwoHandlerSpy = jest.spyOn(broadcastRunnerTwo, "handleMessage");
+
     let currentRunner = broadcastRunnerOne;
 
     const clientsHolder = document.createElement("div");
@@ -171,6 +175,12 @@ describe("broadcast", function() {
       return client.element.querySelectorAll("#inner-element-one").length > 0;
     });
 
+    expect(broadcastRunnerOneHandlerSpy).toHaveBeenCalledWith({
+      message: { connectionId: 1, type: "addConnectedUserId" },
+      revisionId: 1,
+      type: "instance",
+    });
+
     broadcastRunnerOne.dispose();
 
     broadcastReceiver.clearRevisionState();
@@ -186,6 +196,18 @@ describe("broadcast", function() {
 
     await waitFor(() => {
       return client.element.querySelectorAll("#inner-element-two").length > 0;
+    });
+
+    expect(broadcastRunnerOneHandlerSpy).toHaveBeenCalledWith({
+      message: { connectionId: 1, type: "addConnectedUserId" },
+      revisionId: 1,
+      type: "instance",
+    });
+
+    expect(broadcastRunnerTwoHandlerSpy).toHaveBeenNthCalledWith(1, {
+      message: { connectionId: 1, type: "addConnectedUserId" },
+      revisionId: 1,
+      type: "instance",
     });
   });
 });


### PR DESCRIPTION
This PR fixes an issue with using `NetworkedDOMBroadcastReceiver` with a flow that replaces or removes the `NetworkedDOMBroadcastRunner` that is attached to it.

This is both a bugfix and a feature in that explicitly enabling this usage pattern required adding `dispose()`, `clearRevisionState()` and `clearState()` functions.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
