### PR TITLE
Fix sending of hidden elements on reload

### DIFF
--- a/packages/networked-dom-document/src/diffing.ts
+++ b/packages/networked-dom-document/src/diffing.ts
@@ -119,6 +119,10 @@ export function diffFromApplicationOfStaticVirtualDOMMutationRecordToConnection(
       break;
     }
     case "characterData": {
+      const visible = visibleNodesForConnection.has(virtualDOMElement.nodeId);
+      if (!visible) {
+        return null;
+      }
       const diff: TextChangedDiff = {
         type: "textChanged",
         nodeId: virtualDOMElement.nodeId,
@@ -127,6 +131,10 @@ export function diffFromApplicationOfStaticVirtualDOMMutationRecordToConnection(
       return diff;
     }
     case "childList": {
+      const visible = visibleNodesForConnection.has(virtualDOMElement.nodeId);
+      if (!visible) {
+        return null;
+      }
       let previousSibling = mutation.previousSibling;
       let previousNodeId: number | null = null;
       if (previousSibling) {


### PR DESCRIPTION
* This PR fixes a bug where on reloading the `NetworkedDOM` document would send `childrenChanged` messages to clients for elements that should not be visible to that client.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
