### PR TITLE
Fix flash of no content between image src data changes

### DIFF
--- a/packages/mml-web/src/elements/Image.ts
+++ b/packages/mml-web/src/elements/Image.ts
@@ -97,6 +97,16 @@ export class Image extends TransformableElement {
       return;
     }
 
+    if (this.props.src.startsWith("data:image/")) {
+      // if the src is a data url, load it directly rather than using the loader - this avoids a potential frame skip
+      this.loadedImage = document.createElement("img");
+      this.loadedImage.src = this.props.src;
+      this.material.map = new THREE.CanvasTexture(this.loadedImage);
+      this.material.needsUpdate = true;
+      this.updateHeightAndWidth();
+      return;
+    }
+
     const srcApplyPromise = loadImageAsPromise(
       Image.imageLoader,
       this.contentSrcToContentAddress(this.props.src),
@@ -110,7 +120,7 @@ export class Image extends TransformableElement {
           return;
         }
         this.loadedImage = image;
-        this.material.map = new THREE.CanvasTexture(image);
+        this.material.map = new THREE.CanvasTexture(this.loadedImage);
         this.material.needsUpdate = true;
         this.updateHeightAndWidth();
       })


### PR DESCRIPTION
When using `data:image/` values for the `src` of an `m-image` there was the possibility of a frame rendering between the removal of the existing texture map and the image element to derive the new texture loading through a promise.

This PR changes the `src` handling behaviour to construct an `img` tag synchronously if the `src` is `data:image/`

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
