### PR TITLE
Cache lerna build command

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,10 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": ["build"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR configures Lerna to cache the `build` command of all packages, therefore skipping it entirely in most cases which can save ~half of `iterate` startup time too.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Other, please describe: Project config

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
