### PR TITLE
Selectively make elements transparent or not

### DIFF
--- a/packages/mml-web/src/elements/Cube.ts
+++ b/packages/mml-web/src/elements/Cube.ts
@@ -58,7 +58,7 @@ export class Cube extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultCubeOpacity);
       if (instance.material) {
-        instance.material.transparent = instance.props.opacity === 1 ? false : true;
+        instance.material.transparent = instance.props.opacity !== 1;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Cube.ts
+++ b/packages/mml-web/src/elements/Cube.ts
@@ -58,6 +58,7 @@ export class Cube extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultCubeOpacity);
       if (instance.material) {
+        instance.material.transparent = instance.props.opacity === 1 ? false : true;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },
@@ -108,7 +109,7 @@ export class Cube extends TransformableElement {
     super.connectedCallback();
     this.material = new THREE.MeshStandardMaterial({
       color: this.props.color,
-      transparent: true,
+      transparent: this.props.opacity === 1 ? false : true,
       opacity: this.props.opacity,
     });
     this.mesh.material = this.material;

--- a/packages/mml-web/src/elements/Cube.ts
+++ b/packages/mml-web/src/elements/Cube.ts
@@ -58,7 +58,9 @@ export class Cube extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultCubeOpacity);
       if (instance.material) {
+        const needsUpdate = instance.material.transparent === (instance.props.opacity === 1);
         instance.material.transparent = instance.props.opacity !== 1;
+        instance.material.needsUpdate = needsUpdate;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Cylinder.ts
+++ b/packages/mml-web/src/elements/Cylinder.ts
@@ -65,6 +65,7 @@ export class Cylinder extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultCylinderOpacity);
       if (instance.material) {
+        instance.material.transparent = instance.props.opacity === 1 ? false : true;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },
@@ -104,7 +105,7 @@ export class Cylinder extends TransformableElement {
     super.connectedCallback();
     this.material = new THREE.MeshStandardMaterial({
       color: this.props.color,
-      transparent: true,
+      transparent: this.props.opacity === 1 ? false : true,
       opacity: this.props.opacity,
     });
     this.mesh.material = this.material;

--- a/packages/mml-web/src/elements/Cylinder.ts
+++ b/packages/mml-web/src/elements/Cylinder.ts
@@ -65,7 +65,7 @@ export class Cylinder extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultCylinderOpacity);
       if (instance.material) {
-        instance.material.transparent = instance.props.opacity === 1 ? false : true;
+        instance.material.transparent = instance.props.opacity !== 1;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Cylinder.ts
+++ b/packages/mml-web/src/elements/Cylinder.ts
@@ -65,7 +65,9 @@ export class Cylinder extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultCylinderOpacity);
       if (instance.material) {
+        const needsUpdate = instance.material.transparent === (instance.props.opacity === 1);
         instance.material.transparent = instance.props.opacity !== 1;
+        instance.material.needsUpdate = needsUpdate;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Image.ts
+++ b/packages/mml-web/src/elements/Image.ts
@@ -51,6 +51,7 @@ export class Image extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultImageOpacity);
       if (instance.material) {
+        instance.material.transparent = instance.props.opacity === 1 ? false : true;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },
@@ -148,7 +149,7 @@ export class Image extends TransformableElement {
     super.connectedCallback();
     this.material = new THREE.MeshStandardMaterial({
       color: 0xffffff,
-      transparent: true,
+      transparent: this.props.opacity === 1 ? false : true,
       opacity: this.props.opacity,
       side: THREE.DoubleSide,
     });

--- a/packages/mml-web/src/elements/Image.ts
+++ b/packages/mml-web/src/elements/Image.ts
@@ -51,7 +51,7 @@ export class Image extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultImageOpacity);
       if (instance.material) {
-        instance.material.transparent = instance.props.opacity === 1 ? false : true;
+        instance.material.transparent = instance.props.opacity !== 1;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Image.ts
+++ b/packages/mml-web/src/elements/Image.ts
@@ -51,7 +51,9 @@ export class Image extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultImageOpacity);
       if (instance.material) {
+        const needsUpdate = instance.material.transparent === (instance.props.opacity === 1);
         instance.material.transparent = instance.props.opacity !== 1;
+        instance.material.needsUpdate = needsUpdate;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Label.ts
+++ b/packages/mml-web/src/elements/Label.ts
@@ -127,7 +127,7 @@ export class Label extends TransformableElement {
   public connectedCallback(): void {
     super.connectedCallback();
     this.material = new THREE.MeshStandardMaterial({
-      transparent: true,
+      transparent: false,
     });
     this.mesh.material = this.material;
     this.redrawText();

--- a/packages/mml-web/src/elements/Plane.ts
+++ b/packages/mml-web/src/elements/Plane.ts
@@ -51,7 +51,7 @@ export class Plane extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultPlaneOpacity);
       if (instance.material) {
-        instance.material.transparent = instance.props.opacity === 1 ? false : true;
+        instance.material.transparent = instance.props.opacity !== 1;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Plane.ts
+++ b/packages/mml-web/src/elements/Plane.ts
@@ -51,7 +51,9 @@ export class Plane extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultPlaneOpacity);
       if (instance.material) {
+        const needsUpdate = instance.material.transparent === (instance.props.opacity === 1);
         instance.material.transparent = instance.props.opacity !== 1;
+        instance.material.needsUpdate = needsUpdate;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Plane.ts
+++ b/packages/mml-web/src/elements/Plane.ts
@@ -51,6 +51,7 @@ export class Plane extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultPlaneOpacity);
       if (instance.material) {
+        instance.material.transparent = instance.props.opacity === 1 ? false : true;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },
@@ -104,7 +105,7 @@ export class Plane extends TransformableElement {
     super.connectedCallback();
     this.material = new THREE.MeshStandardMaterial({
       color: this.props.color,
-      transparent: true,
+      transparent: this.props.opacity === 1 ? false : true,
       opacity: this.props.opacity,
     });
     this.mesh.material = this.material;

--- a/packages/mml-web/src/elements/Sphere.ts
+++ b/packages/mml-web/src/elements/Sphere.ts
@@ -54,6 +54,7 @@ export class Sphere extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultSphereOpacity);
       if (instance.material) {
+        instance.material.transparent = instance.props.opacity === 1 ? false : true;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },
@@ -107,7 +108,7 @@ export class Sphere extends TransformableElement {
     super.connectedCallback();
     this.material = new THREE.MeshStandardMaterial({
       color: this.props.color,
-      transparent: true,
+      transparent: this.props.opacity === 1 ? false : true,
       opacity: this.props.opacity,
     });
     this.mesh.material = this.material;

--- a/packages/mml-web/src/elements/Sphere.ts
+++ b/packages/mml-web/src/elements/Sphere.ts
@@ -54,7 +54,7 @@ export class Sphere extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultSphereOpacity);
       if (instance.material) {
-        instance.material.transparent = instance.props.opacity === 1 ? false : true;
+        instance.material.transparent = instance.props.opacity !== 1;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Sphere.ts
+++ b/packages/mml-web/src/elements/Sphere.ts
@@ -54,7 +54,9 @@ export class Sphere extends TransformableElement {
     opacity: (instance, newValue) => {
       instance.props.opacity = parseFloatAttribute(newValue, defaultSphereOpacity);
       if (instance.material) {
+        const needsUpdate = instance.material.transparent === (instance.props.opacity === 1);
         instance.material.transparent = instance.props.opacity !== 1;
+        instance.material.needsUpdate = needsUpdate;
         instance.material.opacity = parseFloatAttribute(newValue, 1);
       }
     },

--- a/packages/mml-web/src/elements/Video.ts
+++ b/packages/mml-web/src/elements/Video.ts
@@ -112,7 +112,7 @@ export class Video extends TransformableElement {
     const geometry = new THREE.PlaneGeometry(1, 1, 1, 1);
     const material = new THREE.MeshStandardMaterial({
       color: 0xffffff,
-      transparent: true,
+      transparent: false,
       side: THREE.DoubleSide,
     });
     this.mesh = new THREE.Mesh(geometry, material);


### PR DESCRIPTION
Added checks to selectively mark materials as transparent or opaque. On creation, the material’s transparency is set conditionally by the opacity value. Further changes to opacity will update the transparency accordingly in the attribute handler.

The default transparency of elements without an opacity attribute e.g. m-video and m-label is changed to false.

Only objects that are transparent should be marked as transparent. This ensures a lower number of objects are sorted by the renderer, which improves performance and reduces the chance of rendering issues.

### Before
![image](https://github.com/mml-io/mml/assets/33551518/4548fdad-d7fd-4054-aa72-1f41bb6e4176)

### After
![image](https://github.com/mml-io/mml/assets/33551518/a2ee003c-3ad3-49c1-81a2-7cd0a9333500)

The screenshots above were taken using the latest version of the `3d-web-experience` repository

---

**What kind of changes does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [X] The title references the corresponding issue # (if relevant)
