### PR TITLE
Removed "more than one mutation" error log (#101)

### DIFF
--- a/packages/observable-dom/src/ObservableDOM.ts
+++ b/packages/observable-dom/src/ObservableDOM.ts
@@ -139,9 +139,10 @@ export class ObservableDOM implements ObservableDOMInterface {
     }
 
     if (mutationList.length > 1) {
-      // TODO - walk back through the records to derive the intermediate states (e.g. if an attribute is later added to
-      //  an element created in an earlier record then it should not have that attribute when the element is added.
-      //  This is important as incorrect attribute sets can affect visibility and expected client performance.
+      // TODO (https://github.com/mml-io/mml/issues/100) - walk back through the records to derive the intermediate
+      //  states (e.g. if an attribute is later added to an element created in an earlier record then it should not
+      //  have that attribute when the element is added. This is important as incorrect attribute sets can affect
+      //  visibility and expected client performance.
     }
 
     for (const mutation of mutationList) {

--- a/packages/observable-dom/src/ObservableDOM.ts
+++ b/packages/observable-dom/src/ObservableDOM.ts
@@ -142,9 +142,6 @@ export class ObservableDOM implements ObservableDOMInterface {
       // TODO - walk back through the records to derive the intermediate states (e.g. if an attribute is later added to
       //  an element created in an earlier record then it should not have that attribute when the element is added.
       //  This is important as incorrect attribute sets can affect visibility and expected client performance.
-      console.error(
-        "More than one mutation record received. It is possible that intermediate states are incorrect.",
-      );
     }
 
     for (const mutation of mutationList) {


### PR DESCRIPTION
Resolves #101 

This PR removes the often confusing error message `"More than one mutation record received. It is possible that intermediate states are incorrect."`

From [issue](https://github.com/mml-io/mml/issues/101):
> This error line is intrusive, not actionable, and unlikely to hint at a genuine issue for most documents

The underlying issue is now tracked by #100.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Other, please describe: Logging change

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
