### PR TITLE
Fixed missing calls to updateCollider from transformable attribute changes

### DIFF
--- a/packages/mml-web/src/elements/Interaction.ts
+++ b/packages/mml-web/src/elements/Interaction.ts
@@ -100,6 +100,7 @@ export class Interaction extends TransformableElement {
 
   public parentTransformed(): void {
     this.registeredScene?.updateInteraction?.(this);
+    this.showDebug();
   }
 
   public isClickable(): boolean {
@@ -120,12 +121,6 @@ export class Interaction extends TransformableElement {
 
   public attributeChangedCallback(name: string, oldValue: string, newValue: string) {
     super.attributeChangedCallback(name, oldValue, newValue);
-    if (TransformableElement.observedAttributes.includes(name)) {
-      if (this.registeredScene !== null) {
-        this.registeredScene.updateInteraction?.(this);
-      }
-      this.showDebug();
-    }
     if (Interaction.attributeHandler.handle(this, name, newValue)) {
       this.showDebug();
       if (this.registeredScene !== null) {

--- a/packages/mml-web/src/elements/TransformableElement.ts
+++ b/packages/mml-web/src/elements/TransformableElement.ts
@@ -159,6 +159,7 @@ export abstract class TransformableElement extends MElement {
   }
 
   private transformableAttributeChangedValue() {
+    this.parentTransformed();
     traverseChildren(this, (child) => {
       if (child instanceof MElement) {
         child.parentTransformed();

--- a/packages/mml-web/src/utils/CollideableHelper.ts
+++ b/packages/mml-web/src/utils/CollideableHelper.ts
@@ -2,7 +2,6 @@ import * as THREE from "three";
 
 import { AttributeHandler, parseBoolAttribute } from "./attribute-handling";
 import { MElement } from "../elements/MElement";
-import { TransformableElement } from "../elements/TransformableElement";
 import { IMMLScene } from "../MMLScene";
 
 const collideAttributeName = "collide";
@@ -106,11 +105,6 @@ export class CollideableHelper {
 
   public handle(name: string, newValue: string) {
     CollideableHelper.AttributeHandler.handle(this, name, newValue);
-
-    // if the changed attribute is in TransformableElement, then the collider may have changed its position, rotation or scale
-    if (TransformableElement.observedAttributes.includes(name)) {
-      this.updateCollider(this.colliderState.collider);
-    }
   }
 
   public parentTransformed() {


### PR DESCRIPTION
This PR fixes an issue with `m-attr-anim` added in #108 that failed to call `updateCollider` whenever `Transformable` attributes (e.g. `x`, `rx`, `sx`) were updated via animation.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
