### PR TITLE
Corrected m-attr-anim start & end schema types

### DIFF
--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -1227,14 +1227,14 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="start" type="xs:float">
+          <xs:attribute name="start" type="xs:string">
             <xs:annotation>
               <xs:documentation>
                 The value of the attribute that the animation should start at.
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="end" type="xs:float">
+          <xs:attribute name="end" type="xs:string">
             <xs:annotation>
               <xs:documentation>
                 The value of the attribute that the animation should end at.


### PR DESCRIPTION
This PR corrects the `m-attr-anim` attributes `start` and `end` from `xs:float` to the looser `xs:string` as colors are valid values.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
