### PR TITLE
Corrected default end value for m-attr-anim

### DIFF
--- a/packages/mml-web/src/elements/AttributeAnimation.ts
+++ b/packages/mml-web/src/elements/AttributeAnimation.ts
@@ -16,7 +16,7 @@ import {
 
 const defaultAttribute: string | null = null;
 const defaultStart = 0;
-const defaultEnd = 1000;
+const defaultEnd = 0;
 const defaultLoop = true;
 const defaultPingPong = false;
 const defaultEasing = "";


### PR DESCRIPTION
The `end` attribute of `m-attr-anim` should have a default of `0`, but currently has `1000`

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
