### PR TITLE
Fixed duplicate calls to animated attribute handler

### DIFF
--- a/packages/mml-web/src/elements/AttributeAnimation.ts
+++ b/packages/mml-web/src/elements/AttributeAnimation.ts
@@ -1,7 +1,6 @@
 import * as THREE from "three";
 
 import { MElement } from "./MElement";
-import { TransformableElement } from "./TransformableElement";
 import {
   EndOfAnimationSymbol,
   getEasedRatioForTime,
@@ -114,10 +113,7 @@ export class AttributeAnimation extends MElement {
   });
 
   static get observedAttributes(): Array<string> {
-    return [
-      ...TransformableElement.observedAttributes,
-      ...AttributeAnimation.attributeHandler.getAttributes(),
-    ];
+    return [...AttributeAnimation.attributeHandler.getAttributes()];
   }
   constructor() {
     super();

--- a/packages/mml-web/src/elements/RemoteDocument.ts
+++ b/packages/mml-web/src/elements/RemoteDocument.ts
@@ -94,7 +94,7 @@ export class RemoteDocument extends MElement {
     return this.scene;
   }
 
-  private tick() {
+  public tick() {
     this.documentRoot.tick();
     this.animationFrameCallback = window.requestAnimationFrame(() => {
       this.tick();

--- a/packages/mml-web/test/attr-anim.test.ts
+++ b/packages/mml-web/test/attr-anim.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { AudioContext } from "standardized-audio-context-mock";
+
+import { createSceneAttachedElement, createTestScene } from "./scene-test-utils";
+import { testElementSchemaMatchesObservedAttributes } from "./schema-utils";
+import { Cube } from "../src";
+import { AttributeAnimation } from "../src/elements/AttributeAnimation";
+import { registerCustomElementsToWindow } from "../src/elements/register-custom-elements";
+
+beforeAll(() => {
+  (window as any).AudioContext = AudioContext;
+  registerCustomElementsToWindow(window);
+});
+
+describe("m-attr-anim", () => {
+  test("observes the schema-specified attributes", () => {
+    const schema = testElementSchemaMatchesObservedAttributes("m-attr-anim", AttributeAnimation);
+    expect(schema.name).toEqual(AttributeAnimation.tagName);
+  });
+
+  test("test attachment to scene", () => {
+    const { scene, element } = createSceneAttachedElement<AttributeAnimation>("m-attr-anim");
+    expect(
+      scene.getThreeScene().children[0 /* root container */].children[0 /* attachment container */]
+        .children[0 /* element container */],
+    ).toBe(element.getContainer());
+  });
+
+  test("animates parent element attribute - add and remove", () => {
+    const { sceneAttachment } = createTestScene();
+    const cube = document.createElement("m-cube") as Cube;
+    cube.setAttribute("x", "0");
+    cube.setAttribute("y", "2");
+    sceneAttachment.overrideDocumentTime(0);
+
+    const transformableAttributeChangedValueSpy = jest.spyOn(
+      cube as any,
+      "transformableAttributeChangedValue",
+    );
+    sceneAttachment.append(cube);
+    expect(transformableAttributeChangedValueSpy).toHaveBeenCalledTimes(0);
+    cube.setAttribute("x", "1");
+    expect(transformableAttributeChangedValueSpy).toHaveBeenCalledTimes(1);
+
+    expect(cube.getContainer().position.x).toEqual(1);
+    expect(cube.getContainer().position.y).toEqual(2);
+
+    const attrAnim = document.createElement("m-attr-anim") as AttributeAnimation;
+    attrAnim.setAttribute("attr", "x");
+    attrAnim.setAttribute("start", "10");
+    attrAnim.setAttribute("end", "20");
+    attrAnim.setAttribute("loop", "false");
+    attrAnim.setAttribute("duration", "1000");
+    cube.append(attrAnim);
+
+    // Halfway through the animation
+    sceneAttachment.overrideDocumentTime(500);
+    sceneAttachment.tick();
+    expect(cube.getContainer().position.x).toEqual(15);
+    expect(cube.getContainer().position.y).toEqual(2);
+    expect(transformableAttributeChangedValueSpy).toHaveBeenCalledTimes(2);
+
+    // Animation finishes
+    sceneAttachment.overrideDocumentTime(1000);
+    sceneAttachment.tick();
+    expect(cube.getContainer().position.x).toEqual(20);
+    expect(cube.getContainer().position.y).toEqual(2);
+    expect(transformableAttributeChangedValueSpy).toHaveBeenCalledTimes(3);
+
+    // Animation remains finished - the value should not be repeatedly set
+    sceneAttachment.overrideDocumentTime(1500);
+    sceneAttachment.tick();
+    expect(cube.getContainer().position.x).toEqual(20);
+    expect(cube.getContainer().position.y).toEqual(2);
+    expect(transformableAttributeChangedValueSpy).toHaveBeenCalledTimes(3);
+
+    // Removing the animation element should reset the value of the parent to the attribute value
+    attrAnim.remove();
+    sceneAttachment.tick();
+    expect(cube.getContainer().position.x).toEqual(1);
+    expect(cube.getContainer().position.y).toEqual(2);
+    expect(transformableAttributeChangedValueSpy).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
This PR refactors the `AnimatedAttributeHelper` class to improve type safety, and fixes a significant performance issue where animated attribute handlers would be repeatedly called with an unchanged value.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
