### PR TITLE
Optimize relative position calculation

### DIFF
--- a/packages/mml-web/src/utils/position-utils.ts
+++ b/packages/mml-web/src/utils/position-utils.ts
@@ -16,7 +16,7 @@ export function getRelativePositionAndRotationRelativeToObject(
   const { x, y, z } = positionAndRotation.position;
   const { x: rx, y: ry, z: rz } = positionAndRotation.rotation;
 
-  container.updateMatrixWorld();
+  container.updateWorldMatrix(true, false);
   tempContainerMatrix.copy(container.matrixWorld).invert();
 
   tempPositionVector.set(x, y, z);


### PR DESCRIPTION
This PR replaces a call to `updateMatrixWorld()` with `updateWorldMatrix(true, false)` which avoids unnecessarily recalculating the `matrixWorld` of all child objects to determine the `matrixWorld` of just the target object. This is a large cost saving if the target object has many descendants.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Other, please describe: Optimization

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
