### PR TITLE
Add MML window connection events types

### DIFF
--- a/packages/mml-react-types/src/createAttributeGroupsDefinitions.ts
+++ b/packages/mml-react-types/src/createAttributeGroupsDefinitions.ts
@@ -77,8 +77,10 @@ function createAttributeGroupDeclarations(
 
   let eventHandlersDeclarations: Array<ts.MethodSignature> = [];
   let eventMapInterfaceDeclaration;
+
   if (scriptAttributes.length > 0) {
     const eventMapTypeName = ts.factory.createIdentifier(`${capitalizedTypeName}EventMap`);
+
     eventMapInterfaceDeclaration = createEventMapInterfaceDeclaration(
       eventMapTypeName,
       scriptAttributes,

--- a/packages/mml-react-types/src/createEventHandlerDeclarations.ts
+++ b/packages/mml-react-types/src/createEventHandlerDeclarations.ts
@@ -131,7 +131,7 @@ export function createEventHandlerDeclarations(eventMapTypeName: ts.Identifier) 
         ts.factory.createToken(ts.SyntaxKind.QuestionToken),
         ts.factory.createUnionTypeNode([
           ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
-          ts.factory.createTypeReferenceNode("AddEventListenerOptions", undefined),
+          ts.factory.createTypeReferenceNode("EventListenerOptions", undefined),
         ]),
       ),
     ],
@@ -193,7 +193,7 @@ export function createEventHandlerDeclarations(eventMapTypeName: ts.Identifier) 
         ts.factory.createToken(ts.SyntaxKind.QuestionToken),
         ts.factory.createUnionTypeNode([
           ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
-          ts.factory.createTypeReferenceNode("AddEventListenerOptions", undefined),
+          ts.factory.createTypeReferenceNode("EventListenerOptions", undefined),
         ]),
       ),
     ],

--- a/packages/mml-react-types/src/createTSDeclarationsFile.ts
+++ b/packages/mml-react-types/src/createTSDeclarationsFile.ts
@@ -5,6 +5,7 @@ import ts from "typescript";
 import { createAttributeGroupsDefinitions } from "./createAttributeGroupsDefinitions";
 import { createElementsDeclarations } from "./createElementsDeclarations";
 import { createReactCoreAttributesType } from "./createReactCoreAttributesType";
+import { createWindowEventMapDeclaration } from "./createWindowEvents";
 import { getGlobalDeclaration } from "./getGlobalDeclaration";
 
 export function createTSDeclarationsFile(
@@ -24,6 +25,9 @@ export function createTSDeclarationsFile(
   const attributeGroups = createAttributeGroupsDefinitions(attributeGroupsJSON);
   const elements = createElementsDeclarations(elementsJSON);
   declarationStatements.push(...attributeGroups, ...elements);
+
+  const windowEventsMap = createWindowEventMapDeclaration();
+  declarationStatements.push(windowEventsMap);
 
   // We create the global declaration for the file
   const globalDeclaration = getGlobalDeclaration(elementsJSON);

--- a/packages/mml-react-types/src/createWindowEvents.ts
+++ b/packages/mml-react-types/src/createWindowEvents.ts
@@ -153,7 +153,7 @@ export function createWindowInterfaceDeclaration() {
   );
 
   const windowInstanceDeclaration = ts.factory.createInterfaceDeclaration(
-    [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+    undefined,
     ts.factory.createIdentifier("Window"),
     undefined,
     [

--- a/packages/mml-react-types/src/createWindowEvents.ts
+++ b/packages/mml-react-types/src/createWindowEvents.ts
@@ -1,0 +1,171 @@
+import ts from "typescript";
+
+import {
+  createEventHandlerDeclarations,
+  createEventMapInterfaceDeclaration,
+} from "./createEventHandlerDeclarations";
+
+// Hardcoding it since it doesn't seem possible to retrieve them from schema
+const SCRIPT_ATTRIBUTES = [
+  {
+    name: "connected",
+    eventName: "connected",
+    eventClass: "ConnectionEvent",
+  },
+  {
+    name: "disconnected",
+    eventName: "disconnected",
+    eventClass: "ConnectionEvent",
+  },
+];
+
+const typeName = ts.factory.createIdentifier("WindowEventMap");
+
+export function createWindowEventMapDeclaration() {
+  const windowEventMapDeclaration = createEventMapInterfaceDeclaration(typeName, SCRIPT_ATTRIBUTES);
+
+  return windowEventMapDeclaration;
+}
+
+export function createWindowInterfaceDeclaration() {
+  const addEventListenerMethod = ts.factory.createMethodSignature(
+    undefined,
+    "addEventListener",
+    undefined,
+    [
+      ts.factory.createTypeParameterDeclaration(
+        undefined,
+        "K",
+        ts.factory.createTypeReferenceNode("keyof " + typeName.text, undefined),
+      ),
+    ],
+    [
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        "type",
+        undefined,
+        ts.factory.createTypeReferenceNode("K", undefined),
+      ),
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        "listener",
+        undefined,
+        ts.factory.createFunctionTypeNode(
+          undefined,
+          [
+            ts.factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              "this",
+              undefined,
+              ts.factory.createTypeReferenceNode("Window", undefined),
+            ),
+            ts.factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              "ev",
+              undefined,
+              ts.factory.createIndexedAccessTypeNode(
+                ts.factory.createTypeReferenceNode(typeName, undefined),
+                ts.factory.createTypeReferenceNode("K", undefined),
+              ),
+            ),
+          ],
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+        ),
+      ),
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        "options",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        ts.factory.createUnionTypeNode([
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
+          ts.factory.createTypeReferenceNode("AddEventListenerOptions", undefined),
+        ]),
+      ),
+    ],
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword),
+  );
+
+  const removeEventListenerMethod = ts.factory.createMethodSignature(
+    undefined,
+    "removeEventListener",
+    undefined,
+    [
+      ts.factory.createTypeParameterDeclaration(
+        undefined,
+        "K",
+        ts.factory.createTypeReferenceNode("keyof " + typeName.text, undefined),
+      ),
+    ],
+    [
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        "type",
+        undefined,
+        ts.factory.createTypeReferenceNode("K", undefined),
+      ),
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        "listener",
+        undefined,
+        ts.factory.createFunctionTypeNode(
+          undefined,
+          [
+            ts.factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              "this",
+              undefined,
+              ts.factory.createTypeReferenceNode("Window", undefined),
+            ),
+            ts.factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              "ev",
+              undefined,
+              ts.factory.createIndexedAccessTypeNode(
+                ts.factory.createTypeReferenceNode(typeName, undefined),
+                ts.factory.createTypeReferenceNode("K", undefined),
+              ),
+            ),
+          ],
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+        ),
+      ),
+      ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        "options",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        ts.factory.createUnionTypeNode([
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
+          ts.factory.createTypeReferenceNode("EventListenerOptions", undefined),
+        ]),
+      ),
+    ],
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword),
+  );
+
+  const windowInstanceDeclaration = ts.factory.createInterfaceDeclaration(
+    [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createIdentifier("Window"),
+    undefined,
+    [
+      ts.factory.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [
+        ts.factory.createExpressionWithTypeArguments(
+          ts.factory.createIdentifier("EventTarget"),
+          undefined,
+        ),
+      ]),
+    ],
+    [addEventListenerMethod, removeEventListenerMethod],
+  );
+
+  return windowInstanceDeclaration;
+}

--- a/packages/mml-react-types/src/getGlobalDeclaration.ts
+++ b/packages/mml-react-types/src/getGlobalDeclaration.ts
@@ -1,13 +1,17 @@
 import { Element } from "@mml-io/mml-schema";
 import ts from "typescript";
 
+import { createWindowInterfaceDeclaration } from "./createWindowEvents";
 import { getMMLElementAttributesName } from "./util";
 
 export function getGlobalDeclaration(elements: { [key: string]: Element }) {
+  const windowEventMapDeclaration = createWindowInterfaceDeclaration();
+
   return ts.factory.createModuleDeclaration(
     undefined,
     ts.factory.createIdentifier("global"),
     ts.factory.createModuleBlock([
+      windowEventMapDeclaration,
       ts.factory.createModuleDeclaration(
         undefined,
         ts.factory.createIdentifier("JSX"),


### PR DESCRIPTION
The code adds window events for connection and disconnection.

It also changes the types for  `removeEventListener` options from `AddEventListenerOptions` to `EventListenerOptions` which seems to be the correct one.

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
