### PR TITLE
Directional m-audio (#65)

### DIFF
--- a/packages/mml-web/src/types/PositionalAudioHelper.d.ts.tsx
+++ b/packages/mml-web/src/types/PositionalAudioHelper.d.ts.tsx
@@ -1,0 +1,18 @@
+declare module "three/addons/helpers/PositionalAudioHelper.js" {
+  import { Object3D, PositionalAudio } from "three";
+  export class PositionalAudioHelper extends Object3D {
+    constructor(
+      audio: PositionalAudio,
+      range?: number,
+      divisionsInnerAngle?: number,
+      divisionsOuterAngle?: number,
+    );
+    audio: PositionalAudio;
+    range: number;
+    divisionsInnerAngle: number;
+    divisionsOuterAngle: number;
+    matrixAutoUpdate: boolean;
+    update(): void;
+    dispose(): void;
+  }
+}

--- a/packages/schema-validator/test/elements/m-audio.test.ts
+++ b/packages/schema-validator/test/elements/m-audio.test.ts
@@ -19,6 +19,8 @@ test("<m-audio>", () => {
   loop="true"
   enabled="true"
   volume="1.5"
+  cone-angle="120"
+  cone-falloff-angle="180"
 ></m-audio>
 `);
   expect(validationErrors).toBeNull();

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -797,6 +797,20 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="cone-angle" type="xs:float">
+            <xs:annotation>
+              <xs:documentation>
+                A double value describing the angle, in degrees, of a cone inside of which there will be no volume reduction.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="cone-falloff-angle" type="xs:float">
+            <xs:annotation>
+              <xs:documentation>
+                A double value describing the angle, in degrees, of a cone outside of which the volume will be reduced by a constant value (0).
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
           <xs:attribute name="start-time" type="xs:integer">
             <xs:annotation>
               <xs:documentation>

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -800,14 +800,14 @@
           <xs:attribute name="cone-angle" type="xs:float">
             <xs:annotation>
               <xs:documentation>
-               The angle within which sound is at full volume. Default value is 360 (the sound is not directional).
+                The angle in degrees within which sound is at full volume. Default value is 360 (the sound is not directional).
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
           <xs:attribute name="cone-falloff-angle" type="xs:float">
             <xs:annotation>
               <xs:documentation>
-                The angle beyond which sound is inaudible. Default value is 0.
+                The angle in degrees beyond which sound is inaudible. Must be greater than `cone-angle` to have an effect. Default value is 0 (there is no gradual drop-off).
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -800,14 +800,14 @@
           <xs:attribute name="cone-angle" type="xs:float">
             <xs:annotation>
               <xs:documentation>
-                A double value describing the angle, in degrees, of a cone inside of which there will be no volume reduction.
+               The angle within which sound is at full volume. Default value is 360 (the sound is not directional).
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
           <xs:attribute name="cone-falloff-angle" type="xs:float">
             <xs:annotation>
               <xs:documentation>
-                A double value describing the angle, in degrees, of a cone outside of which the volume will be reduced by a constant value (0).
+                The angle beyond which sound is inaudible. Default value is 0.
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>


### PR DESCRIPTION
Closes #65 
This adds two attributes to the `m-audio` tag:

`cone-angle` and `cone-falloff-angle`

It adds them to the schema as well, using the description used on the [PannerNode API](https://developer.mozilla.org/en-US/docs/Web/API/PannerNode)

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
