### PR TITLE
Update schema definition for m-attr-anim

### DIFF
--- a/packages/mml-react-types/src/util.ts
+++ b/packages/mml-react-types/src/util.ts
@@ -23,6 +23,7 @@ const schemaToTSTypeMap = {
   "xs:string": "string",
   "xs:boolean": "boolean",
   URI: "string",
+  StringOrFloat: "number",
 } as const;
 
 export function getAttributeGroupName(attributeGroupName: string) {

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -28,6 +28,10 @@
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
 
+  <xs:simpleType name="StringOrFloat">
+    <xs:union memberTypes="xs:string xs:float" />
+  </xs:simpleType>
+
   <xs:simpleType name="URI">
     <xs:annotation>
       <xs:documentation>
@@ -1227,14 +1231,14 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="start" type="xs:string">
+          <xs:attribute name="start" type="StringOrFloat">
             <xs:annotation>
               <xs:documentation>
                 The value of the attribute that the animation should start at.
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="end" type="xs:string">
+          <xs:attribute name="end" type="StringOrFloat">
             <xs:annotation>
               <xs:documentation>
                 The value of the attribute that the animation should end at.
@@ -1329,3 +1333,4 @@
     </xs:complexType>
   </xs:element>
 </xs:schema>
+


### PR DESCRIPTION
Updated schema definition to accept start and end on `m-attr-anim` as both string and number
Updated TS generation to handle the new type

**What kind of changes does your PR introduce?** (check at least one)

- [x] Other, please describe: Update current schema definition to add a mixed type

**Does your PR introduce a breaking change?** (check one)

- [x] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
