### PR TITLE
(CI) Allow nx unknown local cache

### DIFF
--- a/.github/actions/npm-install-build-and-cache/action.yaml
+++ b/.github/actions/npm-install-build-and-cache/action.yaml
@@ -16,6 +16,12 @@ runs:
         node-version-file: ".nvmrc"
         cache: npm
 
+    # Set NX_REJECT_UNKNOWN_LOCAL_CACHE=0 to allow NX to use the local cache even if the cache was built by a different machine
+    # https://nx.dev/recipes/troubleshooting/unknown-local-cache
+    - name: Allow NX to use unknown local cache
+      shell: bash
+      run: echo "NX_REJECT_UNKNOWN_LOCAL_CACHE=0" >> $GITHUB_ENV
+
     - name: Cache NPM dependencies
       uses: actions/cache@v3
       id: cache-npm-deps


### PR DESCRIPTION
Fix an issue where NX will reject the GitHub Actions cache if the machine does not match. See https://github.com/mml-io/mml/actions/runs/6273240490/job/17036977664#step:3:106 for an example.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Other, please describe: CI config fix