### PR TITLE
Added support for "on" attribute event handlers in WebBrowserDOMRunner (#120)

### DIFF
--- a/packages/networked-dom-web-runner/networked-dom-web-runner-iframe/src/WebBrowserDOMRunner.ts
+++ b/packages/networked-dom-web-runner/networked-dom-web-runner-iframe/src/WebBrowserDOMRunner.ts
@@ -108,6 +108,23 @@ export class WebBrowserDOMRunner implements DOMRunnerInterface {
       detail: { ...remoteEvent.params, connectionId },
     });
 
+    const eventTypeLowerCase = remoteEvent.name.toLowerCase();
+
+    // TODO - check if there are other events that automatically wire up similarly to click->onclick and avoid those too
+    if (eventTypeLowerCase !== "click") {
+      const handlerAttributeName = "on" + eventTypeLowerCase;
+      const handlerAttributeValue = realElement.getAttribute(handlerAttributeName);
+      if (handlerAttributeValue) {
+        // This event is defined as an HTML event attribute.
+        try {
+          const fn = Function("event", handlerAttributeValue);
+          fn.apply(realElement, [remoteEventObject]);
+        } catch (e) {
+          console.error("Error running event handler:", e);
+        }
+      }
+    }
+
     // Dispatch the event via JavaScript.
     realElement.dispatchEvent(remoteEventObject);
   }


### PR DESCRIPTION
Fixes #120 

This PR adds support / fixes a gap when using `on` attributes (e.g. `onpositionmove="doAThing(event)"`) when the MML document is executing in a browser using the `networked-dom-web-runner` package.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
