### PR TITLE
Add loading progress callbacks (#129)

### DIFF
--- a/packages/mml-web-client/src/index.ts
+++ b/packages/mml-web-client/src/index.ts
@@ -98,6 +98,7 @@ function createStatusElement() {
         (status: NetworkedDOMWebsocketStatus) => {
           if (status === NetworkedDOMWebsocketStatus.Connected) {
             statusElement.style.display = "none";
+            fullScreenMMLScene.getLoadingProgressManager().setInitialLoad(true);
           } else {
             statusElement.style.display = "block";
             statusElement.textContent = NetworkedDOMWebsocketStatus[status];

--- a/packages/mml-web/src/FullScreenMMLScene.ts
+++ b/packages/mml-web/src/FullScreenMMLScene.ts
@@ -1,8 +1,16 @@
 import { MMLScene } from "./MMLScene";
+import { LoadingProgressBar } from "./utils/loading/LoadingProgressBar";
 
 export class FullScreenMMLScene extends MMLScene {
+  private loadingProgressBar: LoadingProgressBar;
+
   constructor() {
     super();
+
+    const loadingProgressManager = this.getLoadingProgressManager();
+    this.loadingProgressBar = new LoadingProgressBar(loadingProgressManager);
+    this.element.append(this.loadingProgressBar.element);
+
     this.configureWindowStyling();
   }
 

--- a/packages/mml-web/src/MMLScene.ts
+++ b/packages/mml-web/src/MMLScene.ts
@@ -9,6 +9,7 @@ import { MElement } from "./elements/MElement";
 import { InteractionManager } from "./interaction-ui";
 import { MMLClickTrigger } from "./MMLClickTrigger";
 import { PromptManager } from "./prompt-ui";
+import { LoadingProgressManager } from "./utils/loading/LoadingProgressManager";
 
 export type PositionAndRotation = {
   position: { x: number; y: number; z: number };
@@ -60,6 +61,8 @@ export type IMMLScene = {
   getUserPositionAndRotation(): PositionAndRotation;
 
   prompt: (promptProps: PromptProps, callback: (message: string | null) => void) => void;
+
+  getLoadingProgressManager?: () => LoadingProgressManager | null;
 };
 
 export enum ControlsType {
@@ -100,8 +103,9 @@ export class MMLScene implements IMMLScene {
   private promptManager: PromptManager;
   private interactionManager: InteractionManager;
   private resizeObserver: ResizeObserver;
+  private loadingProgressManager: LoadingProgressManager;
 
-  constructor(mmlSceneOptions: MMLSceneOptions = {}) {
+  constructor(private options: MMLSceneOptions = {}) {
     this.element = document.createElement("div");
     this.element.style.width = "100%";
     this.element.style.height = "100%";
@@ -110,6 +114,8 @@ export class MMLScene implements IMMLScene {
     this.rootContainer = new THREE.Group();
     this.threeScene = new THREE.Scene();
     this.threeScene.add(this.rootContainer);
+
+    this.loadingProgressManager = new LoadingProgressManager();
 
     this.camera = new THREE.PerspectiveCamera(
       75,
@@ -140,7 +146,7 @@ export class MMLScene implements IMMLScene {
     });
     this.resizeObserver.observe(this.element);
 
-    switch (mmlSceneOptions.controlsType) {
+    switch (options.controlsType) {
       case ControlsType.None:
         break;
       case ControlsType.PointerLockFly:
@@ -183,6 +189,7 @@ export class MMLScene implements IMMLScene {
     window.addEventListener("resize", this.resizeListener, false);
 
     this.element.appendChild(this.renderer.domElement);
+
     this.fitContainer();
   }
 
@@ -339,6 +346,10 @@ export class MMLScene implements IMMLScene {
     for (const listener of this.chatProbeListeners) {
       listener.removeChatProbe(chatProbe);
     }
+  }
+
+  public getLoadingProgressManager(): LoadingProgressManager {
+    return this.loadingProgressManager;
   }
 
   public getChatProbes(): Set<ChatProbe> {

--- a/packages/mml-web/src/elements/MElement.ts
+++ b/packages/mml-web/src/elements/MElement.ts
@@ -5,6 +5,7 @@ import { consumeEventEventName } from "../common";
 import { getGlobalDocumentTimeManager, getGlobalMMLScene } from "../global";
 import { MMLDocumentTimeManager } from "../MMLDocumentTimeManager";
 import { IMMLScene, PositionAndRotation } from "../MMLScene";
+import { LoadingProgressManager } from "../utils/loading/LoadingProgressManager";
 
 const MELEMENT_PROPERTY_NAME = "m-element-property";
 
@@ -117,6 +118,14 @@ export abstract class MElement extends HTMLElement {
     const documentTimeContextProvider = this.getDocumentTimeManager();
     if (documentTimeContextProvider) {
       return documentTimeContextProvider.getDocumentTime();
+    }
+    return null;
+  }
+
+  protected getLoadingProgressManager(): LoadingProgressManager | null {
+    const scene = this.getScene();
+    if (scene) {
+      return scene.getLoadingProgressManager?.() || null;
     }
     return null;
   }

--- a/packages/mml-web/src/utils/frame/CreateWrappedScene.ts
+++ b/packages/mml-web/src/utils/frame/CreateWrappedScene.ts
@@ -3,8 +3,13 @@ import * as THREE from "three";
 import { Interaction, MElement } from "../../elements";
 import { ChatProbe } from "../../elements/ChatProbe";
 import { IMMLScene, PromptProps } from "../../MMLScene";
+import { LoadingProgressManager } from "../loading/LoadingProgressManager";
 
-export function createWrappedScene(scene: IMMLScene, container: THREE.Group): IMMLScene {
+export function createWrappedScene(
+  scene: IMMLScene,
+  container: THREE.Group,
+  loadingProgressManager: LoadingProgressManager | null,
+): IMMLScene {
   return {
     addCollider(collider: THREE.Object3D, element: MElement): void {
       if (scene.addCollider) {
@@ -71,6 +76,9 @@ export function createWrappedScene(scene: IMMLScene, container: THREE.Group): IM
     },
     getUserPositionAndRotation: () => {
       return scene.getUserPositionAndRotation();
+    },
+    getLoadingProgressManager: () => {
+      return loadingProgressManager;
     },
   };
 }

--- a/packages/mml-web/src/utils/gltf.ts
+++ b/packages/mml-web/src/utils/gltf.ts
@@ -29,14 +29,22 @@ export type GLTFResult = {
   userData: any;
 };
 
-export function loadGltfAsPromise(gltfLoader: GLTFLoader, path: string): Promise<GLTFResult> {
+export function loadGltfAsPromise(
+  gltfLoader: GLTFLoader,
+  path: string,
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<GLTFResult> {
   return new Promise<GLTFResult>((resolve, reject) => {
     gltfLoader.load(
       path,
       (object: GLTFResult) => {
         resolve(object);
       },
-      undefined,
+      (xhr: ProgressEvent) => {
+        if (onProgress) {
+          onProgress(xhr.loaded, xhr.total);
+        }
+      },
       (error: ErrorEvent) => {
         reject(error);
       },

--- a/packages/mml-web/src/utils/loading/LoadingInstanceManager.ts
+++ b/packages/mml-web/src/utils/loading/LoadingInstanceManager.ts
@@ -1,0 +1,75 @@
+import { LoadingProgressManager } from "./LoadingProgressManager";
+
+const noManagerSymbol = Symbol("NoLoadingProgressManagerProvided");
+
+export class LoadingInstanceManager {
+  // Only set if the instance is loading / has loaded / has errored
+  private currentlyLoadingProgressManager: LoadingProgressManager | typeof noManagerSymbol | null =
+    null;
+
+  constructor(private type: string) {}
+
+  public start(loadingProgressManager: LoadingProgressManager | null, url: string) {
+    if (this.currentlyLoadingProgressManager !== null) {
+      if (this.currentlyLoadingProgressManager !== loadingProgressManager) {
+        throw new Error("Already loading with a different progress manager");
+      }
+      // else the instance is already reported as loading with this progress manager (could be a change in content)
+    } else {
+      // This instance is now loading - report to the progress manager
+      if (!loadingProgressManager) {
+        this.currentlyLoadingProgressManager = noManagerSymbol;
+      } else {
+        this.currentlyLoadingProgressManager = loadingProgressManager;
+        this.currentlyLoadingProgressManager.addLoadingAsset(this, url, this.type);
+      }
+    }
+  }
+
+  public setProgress(ratio: number) {
+    if (!this.currentlyLoadingProgressManager) {
+      throw new Error("Not currently loading - cannot finish");
+    }
+    if (this.currentlyLoadingProgressManager !== noManagerSymbol) {
+      this.currentlyLoadingProgressManager.updateAssetProgress(this, ratio);
+    }
+  }
+
+  // The content being loaded is no longer needed, but the instance may still request content load start again
+  public abortIfLoading() {
+    if (
+      this.currentlyLoadingProgressManager &&
+      this.currentlyLoadingProgressManager !== noManagerSymbol
+    ) {
+      this.currentlyLoadingProgressManager.disposeOfLoadingAsset(this);
+    }
+    this.currentlyLoadingProgressManager = null;
+  }
+
+  // The instance is no longer needed, and will not request content load start again (content may not be loading)
+  public dispose() {
+    this.abortIfLoading();
+  }
+
+  public finish() {
+    if (!this.currentlyLoadingProgressManager) {
+      throw new Error("Not currently loading - cannot finish");
+    }
+    if (this.currentlyLoadingProgressManager !== noManagerSymbol) {
+      this.currentlyLoadingProgressManager.completedLoadingAsset(this);
+    }
+  }
+
+  public error(err?: Error | null) {
+    if (!this.currentlyLoadingProgressManager) {
+      throw new Error("Not currently loading - cannot error");
+    }
+    if (this.currentlyLoadingProgressManager !== noManagerSymbol) {
+      if (err) {
+        this.currentlyLoadingProgressManager.errorLoadingAsset(this, err);
+      } else {
+        this.currentlyLoadingProgressManager.errorLoadingAsset(this, new Error("Unknown error"));
+      }
+    }
+  }
+}

--- a/packages/mml-web/src/utils/loading/LoadingProgressBar.ts
+++ b/packages/mml-web/src/utils/loading/LoadingProgressBar.ts
@@ -1,0 +1,127 @@
+import { LoadingProgressManager } from "./LoadingProgressManager";
+
+export class LoadingProgressBar {
+  public readonly element: HTMLDivElement;
+
+  private progressBarHolder: HTMLDivElement;
+  private progressBar: HTMLDivElement;
+  private loadingStatusText: HTMLDivElement;
+
+  private progressDebugView: HTMLDivElement;
+  private progressDebugElement: HTMLPreElement;
+
+  private debugLabel: HTMLLabelElement;
+  private debugCheckbox: HTMLInputElement;
+
+  private hasCompleted = false;
+  private loadingCallback: () => void;
+
+  constructor(private loadingProgressManager: LoadingProgressManager) {
+    this.element = document.createElement("div");
+    this.element.addEventListener("click", (event) => {
+      event.stopPropagation();
+    });
+    this.element.addEventListener("mousedown", (event) => {
+      event.stopPropagation();
+    });
+    this.element.addEventListener("mousemove", (event) => {
+      event.stopPropagation();
+    });
+    this.element.addEventListener("mouseup", (event) => {
+      event.stopPropagation();
+    });
+
+    this.progressDebugView = document.createElement("div");
+    this.progressDebugView.style.position = "absolute";
+    this.progressDebugView.style.backgroundColor = "rgba(128, 128, 128, 0.25)";
+    this.progressDebugView.style.top = "20";
+    this.progressDebugView.style.left = "0";
+    this.progressDebugView.style.border = "1px solid black";
+    this.progressDebugView.style.maxHeight = "calc(100% - 20px)";
+    this.progressDebugView.style.maxWidth = "100%";
+    this.progressDebugView.style.overflow = "auto";
+    this.element.append(this.progressDebugView);
+
+    this.debugCheckbox = document.createElement("input");
+    this.debugCheckbox.type = "checkbox";
+    this.debugCheckbox.addEventListener("change", () => {
+      this.progressDebugElement.style.display = this.debugCheckbox.checked ? "block" : "none";
+      if (this.hasCompleted) {
+        this.dispose();
+      }
+    });
+
+    this.debugLabel = document.createElement("label");
+    this.debugLabel.textContent = "Debug loading";
+    this.debugLabel.style.fontFamily = "sans-serif";
+    this.debugLabel.style.padding = "5px";
+    this.debugLabel.style.display = "inline-block";
+    this.debugLabel.style.userSelect = "none";
+    this.debugLabel.append(this.debugCheckbox);
+    this.progressDebugView.append(this.debugLabel);
+
+    this.progressDebugElement = document.createElement("pre");
+    this.progressDebugElement.style.margin = "0";
+    this.progressDebugElement.style.display = this.debugCheckbox.checked ? "block" : "none";
+    this.progressDebugView.append(this.progressDebugElement);
+
+    this.progressBarHolder = document.createElement("div");
+    this.progressBarHolder.style.position = "absolute";
+    this.progressBarHolder.style.top = "0";
+    this.progressBarHolder.style.left = "0";
+    this.progressBarHolder.style.width = "100%";
+    this.progressBarHolder.style.backgroundColor = "gray";
+    this.progressBarHolder.style.height = "20px";
+    this.element.append(this.progressBarHolder);
+
+    this.progressBar = document.createElement("div");
+    this.progressBar.style.position = "absolute";
+    this.progressBar.style.top = "0";
+    this.progressBar.style.left = "0";
+    this.progressBar.style.width = "0";
+    this.progressBar.style.height = "100%";
+    this.progressBar.style.backgroundColor = "#0050a4";
+    this.progressBarHolder.append(this.progressBar);
+
+    this.loadingStatusText = document.createElement("div");
+    this.loadingStatusText.style.position = "absolute";
+    this.loadingStatusText.style.top = "0";
+    this.loadingStatusText.style.left = "0";
+    this.loadingStatusText.style.width = "100%";
+    this.loadingStatusText.style.height = "100%";
+    this.loadingStatusText.style.color = "white";
+    this.loadingStatusText.style.textAlign = "center";
+    this.loadingStatusText.style.verticalAlign = "middle";
+    this.loadingStatusText.style.lineHeight = "20px";
+    this.loadingStatusText.style.fontFamily = "sans-serif";
+    this.loadingStatusText.textContent = "Loading...";
+    this.progressBarHolder.append(this.loadingStatusText);
+
+    this.loadingCallback = () => {
+      const [loadingRatio, completedLoading] = this.loadingProgressManager.toRatio();
+      if (completedLoading) {
+        if (!this.hasCompleted) {
+          this.hasCompleted = true;
+          if (!this.debugCheckbox.checked) {
+            this.dispose();
+          }
+        }
+        this.loadingStatusText.textContent = "Completed";
+        this.progressBar.style.width = "100%";
+      } else {
+        this.loadingStatusText.textContent = `Loading... ${(loadingRatio * 100).toFixed(2)}%`;
+        this.progressBar.style.width = `${loadingRatio * 100}%`;
+      }
+      this.progressDebugElement.textContent = LoadingProgressManager.LoadingProgressSummaryToString(
+        this.loadingProgressManager.toSummary(),
+      );
+    };
+
+    this.loadingProgressManager.addProgressCallback(this.loadingCallback);
+  }
+
+  public dispose() {
+    this.loadingProgressManager.removeProgressCallback(this.loadingCallback);
+    this.element.remove();
+  }
+}

--- a/packages/mml-web/src/utils/loading/LoadingProgressManager.ts
+++ b/packages/mml-web/src/utils/loading/LoadingProgressManager.ts
@@ -1,0 +1,280 @@
+type AssetStatus = {
+  type: string;
+  assetUrl: string;
+  progressRatio: number;
+  loadStatus: boolean | Error;
+};
+
+type LoadingCountSummary = {
+  totalLoaded: number;
+  totalErrored: number;
+  totalToLoad: number;
+};
+
+type LoadingProgressSummary = {
+  initialLoad: boolean | Error;
+  summary: LoadingCountSummary;
+  summaryByType: { [key: string]: LoadingCountSummary & { assetErrors: Array<[string, Error]> } };
+  innerDocuments: Array<[string, LoadingProgressSummary]>;
+};
+
+export class LoadingProgressManager {
+  public summary: LoadingCountSummary = {
+    totalLoaded: 0,
+    totalErrored: 0,
+    totalToLoad: 0,
+  };
+
+  public initialLoad: boolean | Error = false;
+
+  public loadingAssets = new Map<unknown, AssetStatus>();
+  public summaryByType = new Map<
+    string,
+    LoadingCountSummary & {
+      assets: Map<unknown, AssetStatus>;
+    }
+  >();
+  public loadingDocuments = new Map<
+    unknown,
+    { documentUrl: string; progressManager: LoadingProgressManager }
+  >();
+
+  private onProgressCallbacks = new Set<() => void>();
+
+  constructor() {}
+
+  public addProgressCallback(callback: () => void): void {
+    this.onProgressCallbacks.add(callback);
+  }
+
+  public removeProgressCallback(callback: () => void): void {
+    this.onProgressCallbacks.delete(callback);
+  }
+
+  private onProgress(): void {
+    for (const callback of this.onProgressCallbacks) {
+      callback();
+    }
+  }
+
+  public addLoadingAsset(ref: unknown, url: string, type: string): void {
+    if (this.loadingAssets.has(ref)) {
+      throw new Error("Asset reference already exists");
+    }
+    const assetRecord: AssetStatus = { type, assetUrl: url, progressRatio: 0, loadStatus: false };
+    this.loadingAssets.set(ref, assetRecord);
+
+    let typeSummary = this.summaryByType.get(type);
+    if (!typeSummary) {
+      typeSummary = { totalLoaded: 0, totalToLoad: 0, totalErrored: 0, assets: new Map() };
+      this.summaryByType.set(type, typeSummary);
+    }
+    typeSummary.assets.set(ref, assetRecord);
+    typeSummary.totalToLoad++;
+    this.summary.totalToLoad++;
+    this.onProgress();
+  }
+
+  public setInitialLoad(result: true | Error): void {
+    if (result instanceof Error) {
+      this.initialLoad = result;
+    } else {
+      this.initialLoad = true;
+    }
+    this.onProgress();
+  }
+
+  public disposeOfLoadingAsset(ref: unknown): void {
+    const asset = this.loadingAssets.get(ref);
+    if (asset) {
+      this.loadingAssets.delete(ref);
+      const { type, loadStatus } = asset;
+      const typeSummary = this.summaryByType.get(type);
+      if (typeSummary) {
+        typeSummary.assets.delete(ref);
+        typeSummary.totalToLoad--;
+        this.summary.totalToLoad--;
+        if (loadStatus === true) {
+          typeSummary.totalLoaded--;
+          this.summary.totalLoaded--;
+        } else if (loadStatus instanceof Error) {
+          typeSummary.totalErrored--;
+          this.summary.totalErrored--;
+        }
+        this.onProgress();
+      }
+    }
+  }
+
+  public errorLoadingAsset(ref: unknown, err: Error) {
+    const asset = this.loadingAssets.get(ref);
+    if (asset) {
+      const { type } = asset;
+      asset.loadStatus = err;
+      const typeSummary = this.summaryByType.get(type);
+      if (typeSummary) {
+        typeSummary.totalErrored++;
+        this.summary.totalErrored++;
+        this.onProgress();
+      }
+    }
+  }
+
+  public updateAssetProgress(ref: unknown, progressRatio: number): void {
+    const asset = this.loadingAssets.get(ref);
+    if (asset) {
+      asset.progressRatio = progressRatio;
+      this.onProgress();
+    }
+  }
+
+  public completedLoadingAsset(ref: unknown): void {
+    const asset = this.loadingAssets.get(ref);
+    if (asset) {
+      const { type } = asset;
+      asset.loadStatus = true;
+      const typeSummary = this.summaryByType.get(type);
+      if (typeSummary) {
+        typeSummary.totalLoaded++;
+        this.summary.totalLoaded++;
+        this.onProgress();
+      }
+    }
+  }
+
+  public addLoadingDocument(
+    ref: unknown,
+    documentUrl: string,
+    progressManager: LoadingProgressManager,
+  ): void {
+    this.loadingDocuments.set(ref, { documentUrl, progressManager });
+    this.onProgress();
+  }
+
+  public removeLoadingDocument(ref: unknown): void {
+    this.loadingDocuments.delete(ref);
+    this.onProgress();
+  }
+
+  public updateDocumentProgress(ref: unknown): void {
+    const loadingDocument = this.loadingDocuments.get(ref);
+    if (loadingDocument) {
+      this.onProgress();
+    }
+  }
+
+  public toSummary(): LoadingProgressSummary {
+    const loadingProgressSummary: LoadingProgressSummary = {
+      initialLoad: this.initialLoad,
+      summary: { ...this.summary },
+      summaryByType: {},
+      innerDocuments: [],
+    };
+
+    for (const [key, ofType] of this.summaryByType) {
+      const ofTypeSummary: LoadingCountSummary & { assetErrors: Array<[string, Error]> } = {
+        totalToLoad: ofType.totalToLoad,
+        totalLoaded: ofType.totalLoaded,
+        totalErrored: ofType.totalErrored,
+        assetErrors: [],
+      };
+      if (ofType.totalErrored > 0) {
+        for (const [, asset] of ofType.assets) {
+          if (asset.loadStatus instanceof Error) {
+            ofTypeSummary.assetErrors.push([asset.assetUrl, asset.loadStatus]);
+          }
+        }
+      }
+      loadingProgressSummary.summaryByType[key] = ofTypeSummary;
+    }
+    for (const [, innerDocProgress] of this.loadingDocuments) {
+      loadingProgressSummary.innerDocuments.push([
+        innerDocProgress.documentUrl,
+        innerDocProgress.progressManager.toSummary(),
+      ]);
+    }
+    return loadingProgressSummary;
+  }
+
+  public static LoadingProgressSummaryToString(
+    loadingProgressSummary: LoadingProgressSummary,
+  ): string {
+    const text: Array<string> = [];
+    const showDocProgress = (docUrl: string, docProgress: LoadingProgressSummary) => {
+      if (docProgress.initialLoad instanceof Error) {
+        text.push(`${docUrl}: Error: ${docProgress.initialLoad.message}`);
+        return;
+      } else if (!docProgress.initialLoad) {
+        text.push(`${docUrl}: Loading...`);
+        return;
+      }
+      text.push(
+        `${docUrl}: (${docProgress.summary.totalLoaded} loaded, ${
+          docProgress.summary.totalErrored
+        } errors) / (${docProgress.summary.totalToLoad} to load) = ${
+          docProgress.summary.totalLoaded + docProgress.summary.totalErrored
+        }/${docProgress.summary.totalToLoad}`,
+      );
+      for (const key in docProgress.summaryByType) {
+        const ofType = docProgress.summaryByType[key];
+        text.push(
+          ` - ${key}: (${ofType.totalLoaded} loaded, ${ofType.totalErrored} errors) / (${
+            ofType.totalToLoad
+          } to load) = ${ofType.totalLoaded + ofType.totalErrored}/${ofType.totalToLoad}`,
+        );
+        if (ofType.totalErrored > 0) {
+          text.push(`   - Errors:`);
+          for (const [assetUrl, error] of ofType.assetErrors) {
+            text.push(`     - ${assetUrl}: ${error.message}`);
+          }
+        }
+      }
+      for (const [innerDocumentUrl, innerDocProgress] of docProgress.innerDocuments) {
+        showDocProgress(innerDocumentUrl, innerDocProgress);
+      }
+    };
+    showDocProgress("root", loadingProgressSummary);
+    return text.join("\n");
+  }
+
+  public toRatio(): [number, boolean] {
+    if (!this.initialLoad) {
+      return [0, false];
+    }
+    if (this.initialLoad instanceof Error) {
+      return [1, true];
+    }
+
+    let totalRatio = 0;
+    let complete = true;
+
+    let numberOfDocuments = this.loadingDocuments.size;
+
+    if (this.summary.totalToLoad > 0) {
+      numberOfDocuments += 1;
+      const loadedAndErrored = this.summary.totalLoaded + this.summary.totalErrored;
+      complete = complete && loadedAndErrored === this.summary.totalToLoad;
+      let directAssetsLoadedRatio = 0;
+      for (const [, asset] of this.loadingAssets) {
+        if (asset.loadStatus instanceof Error || asset.loadStatus) {
+          directAssetsLoadedRatio += 1;
+        } else {
+          directAssetsLoadedRatio += asset.progressRatio;
+        }
+      }
+      directAssetsLoadedRatio /= this.summary.totalToLoad;
+      totalRatio += directAssetsLoadedRatio / numberOfDocuments;
+    } else if (this.loadingDocuments.size === 0) {
+      // There are no assets to load and no inner documents, so loading is complete
+      return [1, true];
+    }
+
+    for (const [, innerDocument] of this.loadingDocuments) {
+      const [innerDocumentRatio, innerDocumentComplete] = innerDocument.progressManager.toRatio();
+      totalRatio += innerDocumentRatio / numberOfDocuments;
+      complete = complete && innerDocumentComplete;
+    }
+
+    return [totalRatio, complete];
+  }
+}

--- a/packages/mml-web/test/LoadingInstanceManager.test.ts
+++ b/packages/mml-web/test/LoadingInstanceManager.test.ts
@@ -1,0 +1,108 @@
+import { jest } from "@jest/globals";
+
+import { LoadingInstanceManager } from "../src/utils/loading/LoadingInstanceManager";
+import { LoadingProgressManager } from "../src/utils/loading/LoadingProgressManager";
+
+describe("LoadingInstanceManager", () => {
+  test("simple load", () => {
+    const mockLoadingProgressManager = {
+      addLoadingAsset: jest.fn(),
+      completedLoadingAsset: jest.fn(),
+    };
+
+    const loadingInstanceManager = new LoadingInstanceManager("test");
+    loadingInstanceManager.start(
+      mockLoadingProgressManager as unknown as LoadingProgressManager,
+      "http://example.com/foo",
+    );
+    expect(mockLoadingProgressManager.addLoadingAsset).toHaveBeenCalledWith(
+      loadingInstanceManager,
+      "http://example.com/foo",
+      "test",
+    );
+    loadingInstanceManager.finish();
+    expect(mockLoadingProgressManager.completedLoadingAsset).toHaveBeenCalledWith(
+      loadingInstanceManager,
+    );
+  });
+
+  test("load with no progress manager", () => {
+    // Just needs to not error
+    const loadingInstanceManager = new LoadingInstanceManager("test");
+    loadingInstanceManager.start(null, "http://example.com/foo");
+    loadingInstanceManager.finish();
+  });
+
+  test("abort load", () => {
+    const mockLoadingProgressManager = {
+      addLoadingAsset: jest.fn(),
+      disposeOfLoadingAsset: jest.fn(),
+    };
+
+    const loadingInstanceManager = new LoadingInstanceManager("test");
+    loadingInstanceManager.start(
+      mockLoadingProgressManager as unknown as LoadingProgressManager,
+      "http://example.com/foo",
+    );
+    expect(mockLoadingProgressManager.addLoadingAsset).toHaveBeenCalledWith(
+      loadingInstanceManager,
+      "http://example.com/foo",
+      "test",
+    );
+    loadingInstanceManager.abortIfLoading();
+    expect(mockLoadingProgressManager.disposeOfLoadingAsset).toHaveBeenCalledWith(
+      loadingInstanceManager,
+    );
+  });
+
+  test("progress", () => {
+    const mockLoadingProgressManager = {
+      addLoadingAsset: jest.fn(),
+      completedLoadingAsset: jest.fn(),
+      updateAssetProgress: jest.fn(),
+    };
+
+    const loadingInstanceManager = new LoadingInstanceManager("test");
+    loadingInstanceManager.start(
+      mockLoadingProgressManager as unknown as LoadingProgressManager,
+      "http://example.com/foo",
+    );
+    expect(mockLoadingProgressManager.addLoadingAsset).toHaveBeenCalledWith(
+      loadingInstanceManager,
+      "http://example.com/foo",
+      "test",
+    );
+    loadingInstanceManager.setProgress(0.5);
+    expect(mockLoadingProgressManager.updateAssetProgress).toHaveBeenCalledWith(
+      loadingInstanceManager,
+      0.5,
+    );
+    loadingInstanceManager.finish();
+    expect(mockLoadingProgressManager.completedLoadingAsset).toHaveBeenCalledWith(
+      loadingInstanceManager,
+    );
+  });
+
+  test("error", () => {
+    const mockLoadingProgressManager = {
+      addLoadingAsset: jest.fn(),
+      errorLoadingAsset: jest.fn(),
+    };
+
+    const loadingInstanceManager = new LoadingInstanceManager("test");
+    loadingInstanceManager.start(
+      mockLoadingProgressManager as unknown as LoadingProgressManager,
+      "http://example.com/foo",
+    );
+    expect(mockLoadingProgressManager.addLoadingAsset).toHaveBeenCalledWith(
+      loadingInstanceManager,
+      "http://example.com/foo",
+      "test",
+    );
+    loadingInstanceManager.error(new Error("Test error"));
+    expect(mockLoadingProgressManager.errorLoadingAsset).toHaveBeenCalledWith(
+      loadingInstanceManager,
+      new Error("Test error"),
+    );
+  });
+});

--- a/packages/mml-web/test/LoadingProgressManager.test.ts
+++ b/packages/mml-web/test/LoadingProgressManager.test.ts
@@ -1,0 +1,639 @@
+import { jest } from "@jest/globals";
+
+import { LoadingProgressManager } from "../src/utils/loading/LoadingProgressManager";
+
+describe("LoadingProgressManager", () => {
+  test("empty", () => {
+    const callback = jest.fn();
+    const manager = new LoadingProgressManager();
+    manager.addProgressCallback(callback);
+
+    expect(callback).toHaveBeenCalledTimes(0);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: false,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 0,
+      },
+      summaryByType: {},
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary())).toEqual(
+      `root: Loading...`,
+    );
+
+    manager.setInitialLoad(true);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 0,
+      },
+      summaryByType: {},
+    });
+    expect(manager.toRatio()).toEqual([1, true]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary())).toEqual(
+      `root: (0 loaded, 0 errors) / (0 to load) = 0/0`,
+    );
+  });
+
+  test("single asset load", () => {
+    const callback = jest.fn();
+    const manager = new LoadingProgressManager();
+    manager.addProgressCallback(callback);
+
+    const ref = {};
+    manager.addLoadingAsset(ref, "http://example.com/foo", "type-foo");
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: false,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 0,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary())).toEqual(
+      `root: Loading...`,
+    );
+
+    manager.setInitialLoad(true);
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 0,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (0 loaded, 0 errors) / (1 to load) = 0/1
+ - type-foo: (0 loaded, 0 errors) / (1 to load) = 0/1`);
+
+    manager.completedLoadingAsset(ref);
+
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 1,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 1,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([1, true]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (1 loaded, 0 errors) / (1 to load) = 1/1
+ - type-foo: (1 loaded, 0 errors) / (1 to load) = 1/1`);
+  });
+
+  test("single asset error", () => {
+    const callback = jest.fn();
+    const manager = new LoadingProgressManager();
+    manager.addProgressCallback(callback);
+
+    const ref = {};
+    manager.addLoadingAsset(ref, "http://example.com/foo", "type-foo");
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: false,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 0,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary())).toEqual(
+      `root: Loading...`,
+    );
+
+    manager.setInitialLoad(true);
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 0,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (0 loaded, 0 errors) / (1 to load) = 0/1
+ - type-foo: (0 loaded, 0 errors) / (1 to load) = 0/1`);
+
+    manager.errorLoadingAsset(ref, new Error("Baz error"));
+
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 1,
+        totalLoaded: 0,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [["http://example.com/foo", new Error("Baz error")]],
+          totalErrored: 1,
+          totalLoaded: 0,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([1, true]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (0 loaded, 1 errors) / (1 to load) = 1/1
+ - type-foo: (0 loaded, 1 errors) / (1 to load) = 1/1
+   - Errors:
+     - http://example.com/foo: Baz error`);
+  });
+
+  test("multi asset load", () => {
+    const callback = jest.fn();
+    const manager = new LoadingProgressManager();
+    manager.addProgressCallback(callback);
+
+    const ref1 = {};
+    manager.addLoadingAsset(ref1, "http://example.com/foo", "type-foo");
+    const ref2 = {};
+    manager.addLoadingAsset(ref2, "http://example.com/foo", "type-foo");
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: false,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 2,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 0,
+          totalToLoad: 2,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary())).toEqual(
+      `root: Loading...`,
+    );
+
+    manager.setInitialLoad(true);
+
+    expect(callback).toHaveBeenCalledTimes(3);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 2,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 0,
+          totalToLoad: 2,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (0 loaded, 0 errors) / (2 to load) = 0/2
+ - type-foo: (0 loaded, 0 errors) / (2 to load) = 0/2`);
+
+    manager.completedLoadingAsset(ref1);
+    expect(callback).toHaveBeenCalledTimes(4);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 1,
+        totalToLoad: 2,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 1,
+          totalToLoad: 2,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0.5, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (1 loaded, 0 errors) / (2 to load) = 1/2
+ - type-foo: (1 loaded, 0 errors) / (2 to load) = 1/2`);
+
+    manager.completedLoadingAsset(ref2);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 2,
+        totalToLoad: 2,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 2,
+          totalToLoad: 2,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([1, true]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (2 loaded, 0 errors) / (2 to load) = 2/2
+ - type-foo: (2 loaded, 0 errors) / (2 to load) = 2/2`);
+  });
+
+  test("inner document load", () => {
+    const callback = jest.fn();
+    const manager = new LoadingProgressManager();
+    manager.addProgressCallback(callback);
+
+    const ref1 = {};
+    manager.addLoadingAsset(ref1, "http://example.com/foo", "type-foo");
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    const documentRef1 = {};
+    const documentRef1LoadingProgressCallback = jest.fn();
+    const documentRef1LoadingProgressManager = new LoadingProgressManager();
+    documentRef1LoadingProgressManager.addProgressCallback(() => {
+      documentRef1LoadingProgressCallback();
+      manager.updateDocumentProgress(documentRef1);
+    });
+    manager.addLoadingDocument(
+      documentRef1,
+      "wss://example.com",
+      documentRef1LoadingProgressManager,
+    );
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: false,
+      innerDocuments: [
+        [
+          "wss://example.com",
+          {
+            initialLoad: false,
+            innerDocuments: [],
+            summary: {
+              totalErrored: 0,
+              totalLoaded: 0,
+              totalToLoad: 0,
+            },
+            summaryByType: {},
+          },
+        ],
+      ],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 0,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary())).toEqual(
+      `root: Loading...`,
+    );
+
+    manager.setInitialLoad(true);
+
+    expect(callback).toHaveBeenCalledTimes(3);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [
+        [
+          "wss://example.com",
+          {
+            initialLoad: false,
+            innerDocuments: [],
+            summary: {
+              totalErrored: 0,
+              totalLoaded: 0,
+              totalToLoad: 0,
+            },
+            summaryByType: {},
+          },
+        ],
+      ],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 0,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 0,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (0 loaded, 0 errors) / (1 to load) = 0/1
+ - type-foo: (0 loaded, 0 errors) / (1 to load) = 0/1
+wss://example.com: Loading...`);
+
+    manager.completedLoadingAsset(ref1);
+
+    expect(callback).toHaveBeenCalledTimes(4);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [
+        [
+          "wss://example.com",
+          {
+            initialLoad: false,
+            innerDocuments: [],
+            summary: {
+              totalErrored: 0,
+              totalLoaded: 0,
+              totalToLoad: 0,
+            },
+            summaryByType: {},
+          },
+        ],
+      ],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 1,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 1,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0.5, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (1 loaded, 0 errors) / (1 to load) = 1/1
+ - type-foo: (1 loaded, 0 errors) / (1 to load) = 1/1
+wss://example.com: Loading...`);
+
+    manager.updateDocumentProgress(documentRef1);
+    expect(callback).toHaveBeenCalledTimes(5);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [
+        [
+          "wss://example.com",
+          {
+            initialLoad: false,
+            innerDocuments: [],
+            summary: {
+              totalErrored: 0,
+              totalLoaded: 0,
+              totalToLoad: 0,
+            },
+            summaryByType: {},
+          },
+        ],
+      ],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 1,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 1,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0.5, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (1 loaded, 0 errors) / (1 to load) = 1/1
+ - type-foo: (1 loaded, 0 errors) / (1 to load) = 1/1
+wss://example.com: Loading...`);
+
+    const innerDocRef1 = {};
+    expect(documentRef1LoadingProgressCallback).toHaveBeenCalledTimes(0);
+    documentRef1LoadingProgressManager.addLoadingAsset(
+      innerDocRef1,
+      "http://example.com/bar",
+      "type-bar",
+    );
+    expect(documentRef1LoadingProgressCallback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(6);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [
+        [
+          "wss://example.com",
+          {
+            initialLoad: false,
+            innerDocuments: [],
+            summary: {
+              totalErrored: 0,
+              totalLoaded: 0,
+              totalToLoad: 1,
+            },
+            summaryByType: {
+              "type-bar": {
+                assetErrors: [],
+                totalErrored: 0,
+                totalLoaded: 0,
+                totalToLoad: 1,
+              },
+            },
+          },
+        ],
+      ],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 1,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 1,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0.5, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (1 loaded, 0 errors) / (1 to load) = 1/1
+ - type-foo: (1 loaded, 0 errors) / (1 to load) = 1/1
+wss://example.com: Loading...`);
+
+    documentRef1LoadingProgressManager.setInitialLoad(true);
+    expect(documentRef1LoadingProgressCallback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledTimes(7);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [
+        [
+          "wss://example.com",
+          {
+            initialLoad: true,
+            innerDocuments: [],
+            summary: {
+              totalErrored: 0,
+              totalLoaded: 0,
+              totalToLoad: 1,
+            },
+            summaryByType: {
+              "type-bar": {
+                assetErrors: [],
+                totalErrored: 0,
+                totalLoaded: 0,
+                totalToLoad: 1,
+              },
+            },
+          },
+        ],
+      ],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 1,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 1,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([0.5, false]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (1 loaded, 0 errors) / (1 to load) = 1/1
+ - type-foo: (1 loaded, 0 errors) / (1 to load) = 1/1
+wss://example.com: (0 loaded, 0 errors) / (1 to load) = 0/1
+ - type-bar: (0 loaded, 0 errors) / (1 to load) = 0/1`);
+
+    documentRef1LoadingProgressManager.completedLoadingAsset(innerDocRef1);
+    expect(documentRef1LoadingProgressCallback).toHaveBeenCalledTimes(3);
+    expect(callback).toHaveBeenCalledTimes(8);
+    expect(manager.toSummary()).toEqual({
+      initialLoad: true,
+      innerDocuments: [
+        [
+          "wss://example.com",
+          {
+            initialLoad: true,
+            innerDocuments: [],
+            summary: {
+              totalErrored: 0,
+              totalLoaded: 1,
+              totalToLoad: 1,
+            },
+            summaryByType: {
+              "type-bar": {
+                assetErrors: [],
+                totalErrored: 0,
+                totalLoaded: 1,
+                totalToLoad: 1,
+              },
+            },
+          },
+        ],
+      ],
+      summary: {
+        totalErrored: 0,
+        totalLoaded: 1,
+        totalToLoad: 1,
+      },
+      summaryByType: {
+        "type-foo": {
+          assetErrors: [],
+          totalErrored: 0,
+          totalLoaded: 1,
+          totalToLoad: 1,
+        },
+      },
+    });
+    expect(manager.toRatio()).toEqual([1, true]);
+    expect(LoadingProgressManager.LoadingProgressSummaryToString(manager.toSummary()))
+      .toEqual(`root: (1 loaded, 0 errors) / (1 to load) = 1/1
+ - type-foo: (1 loaded, 0 errors) / (1 to load) = 1/1
+wss://example.com: (1 loaded, 0 errors) / (1 to load) = 1/1
+ - type-bar: (1 loaded, 0 errors) / (1 to load) = 1/1`);
+  });
+});

--- a/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
+++ b/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
@@ -368,7 +368,6 @@ export class NetworkedDOMWebsocket {
   private handleSnapshot(message: SnapshotMessage) {
     // This websocket is successfully connected. Reset the backoff time.
     this.backoffTime = startingBackoffTimeMilliseconds;
-    this.setStatus(NetworkedDOMWebsocketStatus.Connected);
 
     if (this.currentRoot) {
       this.currentRoot.remove();
@@ -389,6 +388,8 @@ export class NetworkedDOMWebsocket {
     this.currentRoot = element;
     // appending to the tree causes MElements to be constructed
     this.parentElement.append(element);
+
+    this.setStatus(NetworkedDOMWebsocketStatus.Connected);
   }
 
   private handleAttributeChange(message: AttributeChangedDiff) {


### PR DESCRIPTION
Resolves #129 

This PR adds a `LoadingProgressManager` class and adds an instance of it to the `MMLScene` that allows elements with remote content (and nested documents) to reporting loading states, errors, and progress such that the library usage of the `MMLScene` can calculate the overall progress. See the video below for a demonstration.

https://github.com/mml-io/mml/assets/669895/2ec9d6f4-b913-445f-ad25-540fdcd3e32a

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
