### PR TITLE
Add @types to dependencies

### DIFF
--- a/packages/observable-dom/package.json
+++ b/packages/observable-dom/package.json
@@ -20,11 +20,9 @@
   },
   "dependencies": {
     "@mml-io/observable-dom-common": "^0.10.0",
+    "@types/jsdom": "^21.1.2",
+    "@types/node-fetch": "2.6.4",
     "jsdom": "22.1.0",
     "node-fetch": "2.6.12"
-  },
-  "devDependencies": {
-    "@types/jsdom": "^21.1.2",
-    "@types/node-fetch": "2.6.4"
   }
 }


### PR DESCRIPTION
This PR fixes an issue where certain usage of the libraries depend on the types being included as `dependencies` (rather than `devDependencies`.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
