### PR TITLE
Fixed position probe debug visualisation toggling

### DIFF
--- a/packages/mml-web/src/elements/ChatProbe.ts
+++ b/packages/mml-web/src/elements/ChatProbe.ts
@@ -140,6 +140,7 @@ export class ChatProbe extends TransformableElement {
   private clearDebugVisualisation() {
     if (this.debugMesh) {
       this.debugMesh.removeFromParent();
+      this.debugMesh = null;
     }
   }
 

--- a/packages/mml-web/src/elements/PositionProbe.ts
+++ b/packages/mml-web/src/elements/PositionProbe.ts
@@ -211,6 +211,7 @@ export class PositionProbe extends TransformableElement {
   private clearDebugVisualisation() {
     if (this.debugMesh) {
       this.debugMesh.removeFromParent();
+      this.debugMesh = null;
     }
   }
 


### PR DESCRIPTION
Fixes an issue where toggling `m-position-probe`'s `debug` attribute from `true` -> `false` -> `true` would not show the debug visualisation.

Also fixes the same issue with `m-chat-probe`.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
