### PR TITLE
Fix multiple loading start with no progress manager

### DIFF
--- a/packages/mml-web/src/loading/LoadingInstanceManager.ts
+++ b/packages/mml-web/src/loading/LoadingInstanceManager.ts
@@ -11,6 +11,10 @@ export class LoadingInstanceManager {
 
   public start(loadingProgressManager: LoadingProgressManager | null, url: string) {
     if (this.currentlyLoadingProgressManager !== null) {
+      if (this.currentlyLoadingProgressManager === noManagerSymbol && !loadingProgressManager) {
+        // Already loading with no progress manager, and no progress manager provided - do nothing
+        return;
+      }
       if (this.currentlyLoadingProgressManager !== loadingProgressManager) {
         throw new Error("Already loading with a different progress manager");
       }

--- a/packages/mml-web/test/LoadingInstanceManager.test.ts
+++ b/packages/mml-web/test/LoadingInstanceManager.test.ts
@@ -33,6 +33,14 @@ describe("LoadingInstanceManager", () => {
     loadingInstanceManager.finish();
   });
 
+  test("load with no progress manager", () => {
+    // Just needs to not error
+    const loadingInstanceManager = new LoadingInstanceManager("test");
+    loadingInstanceManager.start(null, "http://example.com/foo");
+    loadingInstanceManager.start(null, "http://example.com/bar");
+    loadingInstanceManager.finish();
+  });
+
   test("abort load", () => {
     const mockLoadingProgressManager = {
       addLoadingAsset: jest.fn(),


### PR DESCRIPTION
Fixes a case where there is no loading manager provided and `LoadingInstanceManager.start()` is called multiple times.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
