### PR TITLE
Fix m-image transparency support (#140)

### DIFF
--- a/e2e-tests/src/assets/transparency-test-image.png
+++ b/e2e-tests/src/assets/transparency-test-image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81ec530592cd12a2ae87f2b6883bcb0ac074e7f26bc3c5e2c07ba99cd30fc8aa
+size 41006

--- a/e2e-tests/src/m-image-test.html
+++ b/e2e-tests/src/m-image-test.html
@@ -1,3 +1,8 @@
 <m-plane color="blue" width="15" height="15" rx="-90"></m-plane>
-<m-light type="spotlight" ry="45" rx="65" rz="-45" x="10" y="10" z="10"></m-light>
-<m-image src="/assets/test-image.png" y="4" width="10"></m-image>
+<m-light type="point" ry="45" rx="65" rz="-45" x="10" y="10" z="10"></m-light>
+
+<m-image src="/assets/test-image.png" y="4" x="-3" width="5"></m-image>
+
+<!-- Show a cube behind the transparent image to demonstrate transparency -->
+<m-cube color="red" y="4" x="3" z="-5" height="6" rz="-45"></m-cube>
+<m-image src="/assets/transparency-test-image.png" y="4" x="3" width="5"></m-image>

--- a/e2e-tests/test/__image_snapshots__/m-image-test-ts-m-image-image-visible-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-image-test-ts-m-image-image-visible-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c441f72f10f096ddcff36edf957a66eae5a9735ba32b031d344eba7c233c60c9
-size 72229
+oid sha256:e63d39b14ee52558128031a55b09598dd2d75fc8b0f6582bda7d0e94c6feae73
+size 65733

--- a/e2e-tests/test/__image_snapshots__/m-image-test-ts-m-image-image-visible-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-image-test-ts-m-image-image-visible-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed102da74a2ccda2b531c48f2592b0843c7239bbd4cf2d7013ce90343ce5ce0c
-size 317389
+oid sha256:c441f72f10f096ddcff36edf957a66eae5a9735ba32b031d344eba7c233c60c9
+size 72229

--- a/e2e-tests/test/m-image.test.ts
+++ b/e2e-tests/test/m-image.test.ts
@@ -11,7 +11,9 @@ describe("m-image", () => {
     // Wait for the m-image content to load
     await page.waitForFunction(
       () => {
-        return (document.querySelector("m-image") as any).getImageMesh().scale.y > 3;
+        return Array.from(document.querySelectorAll("m-image") as any).every(
+          (img: any) => img.getImageMesh().scale.y > 3,
+        );
       },
       { timeout: 30000, polling: 100 },
     );


### PR DESCRIPTION
Fixes #140 

This PR fixes support for transparent image sources on `m-image` by detecting if the source image has any transparent pixels and selectively setting `transparent: true` on the material if so. This retains the rendering performance gain in cases where the image is not transparent.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
