### PR TITLE
Fix resetting to attribute default on animation removal

### DIFF
--- a/packages/mml-web/src/utils/AnimatedAttributeHelper.ts
+++ b/packages/mml-web/src/utils/AnimatedAttributeHelper.ts
@@ -52,6 +52,10 @@ function updateIfChangedValue<T extends AnimationType>(
   state: AnimationStateRecord<T>,
   newValue: AnimationTypeToValueType<T> | null,
 ) {
+  if (newValue === null) {
+    // There is no value from the source (likely there are no animations and no attribute value), so use the default.
+    newValue = state.config.defaultValue;
+  }
   if (state.config.latestValue !== newValue) {
     state.config.latestValue = newValue;
     state.config.handler(newValue);


### PR DESCRIPTION
This PR fixes an issue where removing an `m-attr-anim` when the animated/parent element does not have an attribute value to fall back to would also fail to return to the default value.

This was problematic in cases where the default value is non-zero (e.g. scale or opacity) as null values would be coerced to zero.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
