### PR TITLE
socketed transformable elements

### DIFF
--- a/e2e-tests/src/m-model-socket-nest-test.html
+++ b/e2e-tests/src/m-model-socket-nest-test.html
@@ -8,37 +8,28 @@
 
 <script>
   const character = document.getElementById("my-character");
+  let clickedNTimes = 0;
 
-  const referenceObjectsGroup = document.getElementById("reference-objects");
-
-  const createReferenceObject = (type, x, y) => {
-    const model = document.createElement(type);
-    model.setAttribute("x", x);
-    model.setAttribute("y", y);
-    referenceObjectsGroup.appendChild(model);
-  };
-
-  const createSocketedModel = async (socket, targetElement, id, rotation, angle) => {
-    const newChar = document.createElement("m-model");
-    newChar.setAttribute("id", id);
-    newChar.setAttribute("src", "/assets/Body.glb");
-    newChar.setAttribute("socket", socket);
-    newChar.setAttribute(rotation, angle);
-    targetElement.appendChild(newChar);
-    return newChar;
-  };
-
-  character.addEventListener("click", async () => {
+  character.addEventListener("click", () => {
     character.setAttribute("anim-start-time", -2100);
     character.setAttribute("anim-pause-time", 0);
-    const subCharacter = await createSocketedModel("hand_r", character, "sub-character", "rx", "-90");
-    const subSubCharacter = await createSocketedModel(
-      "hand_l",
-      subCharacter,
-      "sub-sub-character",
-      "rx",
-      "90",
-    );
-    createReferenceObject("m-cube", 7, 7);
+
+    if (clickedNTimes === 0) {
+      const subCharacter = document.createElement("m-model");
+      subCharacter.setAttribute("id", "sub-character");
+      subCharacter.setAttribute("src", "/assets/Body.glb");
+      subCharacter.setAttribute("socket", "hand_r");
+      subCharacter.setAttribute("rx", "-90");
+      character.append(subCharacter);
+    } else if (clickedNTimes === 1) {
+      const parent = document.getElementById("sub-character");
+      const subSubCharacter = document.createElement("m-model");
+      subSubCharacter.setAttribute("id", "sub-sub-character");
+      subSubCharacter.setAttribute("src", "/assets/Body.glb");
+      subSubCharacter.setAttribute("socket", "hand_l");
+      subSubCharacter.setAttribute("rx", "90");
+      parent.append(subSubCharacter);
+    }
+    clickedNTimes++;
   });
   </script>

--- a/e2e-tests/src/m-model-socket-nest-test.html
+++ b/e2e-tests/src/m-model-socket-nest-test.html
@@ -32,7 +32,7 @@
     character.setAttribute("anim-start-time", -2100);
     character.setAttribute("anim-pause-time", 0);
     const subCharacter = await createSocketedModel("hand_r", character, "sub-character", "rx", "-90");
-    const subSubCharacter = createSocketedModel(
+    const subSubCharacter = await createSocketedModel(
       "hand_l",
       subCharacter,
       "sub-sub-character",

--- a/e2e-tests/src/m-model-socket-nest-test.html
+++ b/e2e-tests/src/m-model-socket-nest-test.html
@@ -1,0 +1,44 @@
+<m-plane color="#00AACC" width="15" height="15" rx="-90"></m-plane>
+<m-light type="spotlight" ry="45" rx="65" rz="-45" x="10" y="10" z="10"></m-light>
+<m-group id="reference-objects"></m-group>
+
+<m-character sx="5" sy="5" sz="5" anim-enabled="true" anim-loop="true" anim-start-time="-2000" anim-pause-time="0" id="my-character" anim="/assets/idle.glb" src="/assets/Body.glb">
+  <m-model type="Head" src="/assets/Head.glb"></m-model>
+</m-character>
+
+<script>
+  const character = document.getElementById("my-character");
+
+  const referenceObjectsGroup = document.getElementById("reference-objects");
+
+  const createReferenceObject = (type, x, y) => {
+    const model = document.createElement(type);
+    model.setAttribute("x", x);
+    model.setAttribute("y", y);
+    referenceObjectsGroup.appendChild(model);
+  };
+
+  const createSocketedModel = async (socket, targetElement, id, rotation, angle) => {
+    const newChar = document.createElement("m-model");
+    newChar.setAttribute("id", id);
+    newChar.setAttribute("src", "/assets/Body.glb");
+    newChar.setAttribute("socket", socket);
+    newChar.setAttribute(rotation, angle);
+    targetElement.appendChild(newChar);
+    return newChar;
+  };
+
+  character.addEventListener("click", async () => {
+    character.setAttribute("anim-start-time", -2100);
+    character.setAttribute("anim-pause-time", 0);
+    const subCharacter = await createSocketedModel("hand_r", character, "sub-character", "rx", "-90");
+    const subSubCharacter = createSocketedModel(
+      "hand_l",
+      subCharacter,
+      "sub-sub-character",
+      "rx",
+      "90",
+    );
+    createReferenceObject("m-cube", 7, 7);
+  });
+  </script>

--- a/e2e-tests/src/m-model-socket-test.html
+++ b/e2e-tests/src/m-model-socket-test.html
@@ -1,6 +1,24 @@
 <m-plane color="#00AACC" width="15" height="15" rx="-90"></m-plane>
 <m-light type="spotlight" ry="45" rx="65" rz="-45" x="10" y="10" z="10"></m-light>
 
-<m-character sx="5" sy="5" sz="5" anim-enabled="true" anim-loop="true" anim-start-time="-2000" anim-pause-time="0" id="my-character" anim="/assets/idle.glb" src="/assets/Body.glb">
+<m-character
+  id="my-character"
+  sx="5" sy="5" sz="5"
+  anim-enabled="true" anim-loop="true"
+  anim="/assets/idle.glb" src="/assets/Body.glb"
+  anim-start-time="-2000" anim-pause-time="0"
+>
   <m-cube id="socketed-cube" x="0" socket="head" sx="0.25" sy="0.25" sz="0.25"></m-cube>
 </m-character>
+
+<script>
+  const positions = ["hand_l", "hand_r", "", "head"];
+  let positionIndex = 0;
+  const cube = document.getElementById("socketed-cube");
+  cube.addEventListener("click", () => {
+    cube.setAttribute("socket", positions[positionIndex++]);
+    if (positionIndex > 3) {
+      positionIndex = 0;
+    }
+  });
+</script>

--- a/e2e-tests/src/m-model-socket-test.html
+++ b/e2e-tests/src/m-model-socket-test.html
@@ -1,0 +1,6 @@
+<m-plane color="#00AACC" width="15" height="15" rx="-90"></m-plane>
+<m-light type="spotlight" ry="45" rx="65" rz="-45" x="10" y="10" z="10"></m-light>
+
+<m-character sx="5" sy="5" sz="5" anim-enabled="true" anim-loop="true" anim-start-time="-2000" anim-pause-time="0" id="my-character" anim="/assets/idle.glb" src="/assets/Body.glb">
+  <m-cube id="socketed-cube" x="0" socket="head" sx="0.25" sy="0.25" sz="0.25"></m-cube>
+</m-character>

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7942ab616bf0ca6e22fbf15f2edc74fc7062e9c2e381da2502f08b5ae0ef2bd
+size 125891

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-2-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-2-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ba15e886c898b51863db5e450598ad80197bfe27f2bffc8cd474208762c92dc
+size 192848

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-2-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ba15e886c898b51863db5e450598ad80197bfe27f2bffc8cd474208762c92dc
-size 192848
+oid sha256:f44ebed7df40f520623f801b2741b096f8da6f0fa2c5ca09306d32b1114c1078
+size 192849

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-2-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-2-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f44ebed7df40f520623f801b2741b096f8da6f0fa2c5ca09306d32b1114c1078
-size 192849
+oid sha256:46237ef006a12c6f3da59f90589770dc5cab918d7e9911bcba59864ae84a077f
+size 173525

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-3-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-nest-test-ts-m-element-socket-socketed-element-animation-inheritance-3-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4a4f965ed99230fe5c5ffc112a328260c72c582fc06fbf6304b1053b4c10250
+size 192189

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-element-socket-socketed-element-position-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-element-socket-socketed-element-position-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2dede0242dc0529987b250e99975b0d3655a4c82b0ade40002a962728377e3e
+size 121802

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-element-socket-socketed-element-position-2-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-element-socket-socketed-element-position-2-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30ff0910cbc6f0b051fd51a57622324642a9360b55b3dfb9a245d95046dd5141
+size 118727

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-element-socket-socketed-element-position-3-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-element-socket-socketed-element-position-3-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:149232c58e5ef62b93b5855e24d4decb721d16447ed2b70f8542da1c956599d9
+size 121435

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-element-socket-socketed-element-position-4-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-element-socket-socketed-element-position-4-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35cec076386f9cb9e4168cbe6b0a7573beedc8af9bd1a9ee80ecf1f88a06cd1c
+size 122448

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-model-socket-socketed-element-position-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-model-socket-socketed-element-position-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2dede0242dc0529987b250e99975b0d3655a4c82b0ade40002a962728377e3e
+size 121802

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-model-socket-socketed-element-position-2-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-model-socket-socketed-element-position-2-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30ff0910cbc6f0b051fd51a57622324642a9360b55b3dfb9a245d95046dd5141
+size 118727

--- a/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-model-socket-socketed-element-position-3-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-model-socket-test-ts-m-model-socket-socketed-element-position-3-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:149232c58e5ef62b93b5855e24d4decb721d16447ed2b70f8542da1c956599d9
+size 121435

--- a/e2e-tests/test/m-model-socket-nest.test.ts
+++ b/e2e-tests/test/m-model-socket-nest.test.ts
@@ -27,16 +27,24 @@ describe("m-element-socket", () => {
     await takeAndCompareScreenshot(page);
 
     await clickElement(page, "m-character");
-
-    // Wait until reference cube is added
+    // Wait until sub-character is loaded
     await page.waitForFunction(
       () => {
-        const group = document.getElementById("reference-objects");
-        if (group) {
-          const cube = group.querySelector("m-cube");
-          const cubeMesh = (cube as any).getCube();
-          return cubeMesh !== null;
-        }
+        const firstModel = document.getElementById("sub-character");
+        const firstModelMesh = (firstModel as any).getModel();
+        return firstModelMesh !== null;
+      },
+      { timeout: 150000, polling: 100 },
+    );
+    await takeAndCompareScreenshot(page);
+
+    await clickElement(page, "m-character");
+    // Wait until sub-sub-character is loaded
+    await page.waitForFunction(
+      () => {
+        const secondModel = document.getElementById("sub-sub-character");
+        const secondModelMesh = (secondModel as any).getModel();
+        return secondModelMesh !== null;
       },
       { timeout: 150000, polling: 100 },
     );

--- a/e2e-tests/test/m-model-socket-nest.test.ts
+++ b/e2e-tests/test/m-model-socket-nest.test.ts
@@ -1,0 +1,47 @@
+import { clickElement, takeAndCompareScreenshot } from "./testing-utils";
+
+describe("m-element-socket", () => {
+  test("socketed element animation inheritance", async () => {
+    const page = await __BROWSER_GLOBAL__.newPage();
+
+    await page.setViewport({ width: 1024, height: 1024 });
+
+    await page.goto("http://localhost:7079/m-model-socket-nest-test.html/reset");
+
+    await page.waitForSelector("m-character");
+
+    // Wait until the character is loaded
+    await page.waitForFunction(
+      () => {
+        const character = document.querySelector("m-character");
+        return (
+          (character as any).getCharacter() !== null &&
+          (character as any).getCurrentAnimation() !== null
+        );
+      },
+      { timeout: 10000, polling: 100 },
+    );
+
+    await page.waitForSelector("m-model");
+
+    await takeAndCompareScreenshot(page);
+
+    await clickElement(page, "m-character");
+
+    // Wait until reference cube is added
+    await page.waitForFunction(
+      () => {
+        const group = document.getElementById("reference-objects");
+        if (group) {
+          const cube = group.querySelector("m-cube");
+          const cubeMesh = (cube as any).getCube();
+          return cubeMesh !== null;
+        }
+      },
+      { timeout: 150000, polling: 100 },
+    );
+    await takeAndCompareScreenshot(page);
+
+    await page.close();
+  }, 60000);
+});

--- a/e2e-tests/test/m-model-socket.test.ts
+++ b/e2e-tests/test/m-model-socket.test.ts
@@ -28,7 +28,6 @@ describe("m-element-socket", () => {
     let [xPos, yPos, zPos] = await page.evaluate(() => {
       const cube = document.getElementById("socketed-cube") as any;
       cube.setAttribute("socket", "hand_l");
-      console.log(cube.getContainer());
       const worldPos = cube.getContainer().position.clone();
       const xPos = cube.getContainer().getWorldPosition(worldPos).x;
       const yPos = cube.getContainer().getWorldPosition(worldPos).y;
@@ -44,7 +43,6 @@ describe("m-element-socket", () => {
     [xPos, yPos, zPos] = await page.evaluate(() => {
       const cube = document.getElementById("socketed-cube") as any;
       cube.setAttribute("socket", "hand_r");
-      console.log(cube.getContainer());
       const worldPos = cube.getContainer().position.clone();
       const xPos = cube.getContainer().getWorldPosition(worldPos).x;
       const yPos = cube.getContainer().getWorldPosition(worldPos).y;
@@ -60,7 +58,6 @@ describe("m-element-socket", () => {
     [xPos, yPos, zPos] = await page.evaluate(() => {
       const cube = document.getElementById("socketed-cube") as any;
       cube.setAttribute("socket", "");
-      console.log(cube.getContainer());
       const worldPos = cube.getContainer().position.clone();
       const xPos = cube.getContainer().getWorldPosition(worldPos).x;
       const yPos = cube.getContainer().getWorldPosition(worldPos).y;

--- a/e2e-tests/test/m-model-socket.test.ts
+++ b/e2e-tests/test/m-model-socket.test.ts
@@ -1,0 +1,77 @@
+import { takeAndCompareScreenshot } from "./testing-utils";
+
+describe("m-element-socket", () => {
+  test("socketed element position", async () => {
+    const page = await __BROWSER_GLOBAL__.newPage();
+
+    await page.setViewport({ width: 1024, height: 1024 });
+
+    await page.goto("http://localhost:7079/m-model-socket-test.html/reset");
+
+    await page.waitForSelector("m-character");
+
+    // Wait until the character is loaded
+    await page.waitForFunction(
+      () => {
+        const character = document.querySelector("m-character");
+        return (
+          (character as any).getCharacter() !== null &&
+          (character as any).getCurrentAnimation() !== null
+        );
+      },
+      { timeout: 30000, polling: 100 },
+    );
+
+    await takeAndCompareScreenshot(page);
+
+    // socketed m-cube position should match the left hand bone position
+    let [xPos, yPos, zPos] = await page.evaluate(() => {
+      const cube = document.getElementById("socketed-cube") as any;
+      cube.setAttribute("socket", "hand_l");
+      console.log(cube.getContainer());
+      const worldPos = cube.getContainer().position.clone();
+      const xPos = cube.getContainer().getWorldPosition(worldPos).x;
+      const yPos = cube.getContainer().getWorldPosition(worldPos).y;
+      const zPos = cube.getContainer().getWorldPosition(worldPos).z;
+      return [xPos, yPos, zPos];
+    });
+    await takeAndCompareScreenshot(page);
+    expect(Math.abs(xPos - 0.814)).toBeLessThan(0.01);
+    expect(Math.abs(yPos - 4.503)).toBeLessThan(0.01);
+    expect(Math.abs(zPos - 0.307)).toBeLessThan(0.01);
+
+    // socketed m-cube position should match the right hand bone position
+    [xPos, yPos, zPos] = await page.evaluate(() => {
+      const cube = document.getElementById("socketed-cube") as any;
+      cube.setAttribute("socket", "hand_r");
+      console.log(cube.getContainer());
+      const worldPos = cube.getContainer().position.clone();
+      const xPos = cube.getContainer().getWorldPosition(worldPos).x;
+      const yPos = cube.getContainer().getWorldPosition(worldPos).y;
+      const zPos = cube.getContainer().getWorldPosition(worldPos).z;
+      return [xPos, yPos, zPos];
+    });
+    await takeAndCompareScreenshot(page);
+    expect(Math.abs(xPos - -1.836)).toBeLessThan(0.01);
+    expect(Math.abs(yPos - 4.193)).toBeLessThan(0.01);
+    expect(Math.abs(zPos - -0.331)).toBeLessThan(0.01);
+
+    // socketed m-cube position should match its parent origin (0, 0, 0)
+    [xPos, yPos, zPos] = await page.evaluate(() => {
+      const cube = document.getElementById("socketed-cube") as any;
+      cube.setAttribute("socket", "");
+      console.log(cube.getContainer());
+      const worldPos = cube.getContainer().position.clone();
+      const xPos = cube.getContainer().getWorldPosition(worldPos).x;
+      const yPos = cube.getContainer().getWorldPosition(worldPos).y;
+      const zPos = cube.getContainer().getWorldPosition(worldPos).z;
+      return [xPos, yPos, zPos];
+    });
+    await takeAndCompareScreenshot(page);
+    expect(xPos).toBeLessThan(0.01);
+    expect(yPos).toBeLessThan(0.01);
+    expect(zPos).toBeLessThan(0.01);
+
+    await page.close();
+  }, 60000);
+});

--- a/e2e-tests/test/m-model-socket.test.ts
+++ b/e2e-tests/test/m-model-socket.test.ts
@@ -1,4 +1,4 @@
-import { takeAndCompareScreenshot } from "./testing-utils";
+import { clickElement, takeAndCompareScreenshot } from "./testing-utils";
 
 describe("m-element-socket", () => {
   test("socketed element position", async () => {
@@ -24,10 +24,10 @@ describe("m-element-socket", () => {
 
     await takeAndCompareScreenshot(page);
 
+    await clickElement(page, "m-cube");
     // socketed m-cube position should match the left hand bone position
     let [xPos, yPos, zPos] = await page.evaluate(() => {
       const cube = document.getElementById("socketed-cube") as any;
-      cube.setAttribute("socket", "hand_l");
       const worldPos = cube.getContainer().position.clone();
       const xPos = cube.getContainer().getWorldPosition(worldPos).x;
       const yPos = cube.getContainer().getWorldPosition(worldPos).y;
@@ -39,10 +39,10 @@ describe("m-element-socket", () => {
     expect(Math.abs(yPos - 4.503)).toBeLessThan(0.01);
     expect(Math.abs(zPos - 0.307)).toBeLessThan(0.01);
 
+    await clickElement(page, "m-cube");
     // socketed m-cube position should match the right hand bone position
     [xPos, yPos, zPos] = await page.evaluate(() => {
       const cube = document.getElementById("socketed-cube") as any;
-      cube.setAttribute("socket", "hand_r");
       const worldPos = cube.getContainer().position.clone();
       const xPos = cube.getContainer().getWorldPosition(worldPos).x;
       const yPos = cube.getContainer().getWorldPosition(worldPos).y;
@@ -54,10 +54,10 @@ describe("m-element-socket", () => {
     expect(Math.abs(yPos - 4.193)).toBeLessThan(0.01);
     expect(Math.abs(zPos - -0.331)).toBeLessThan(0.01);
 
+    await clickElement(page, "m-cube");
     // socketed m-cube position should match its parent origin (0, 0, 0)
     [xPos, yPos, zPos] = await page.evaluate(() => {
       const cube = document.getElementById("socketed-cube") as any;
-      cube.setAttribute("socket", "");
       const worldPos = cube.getContainer().position.clone();
       const xPos = cube.getContainer().getWorldPosition(worldPos).x;
       const yPos = cube.getContainer().getWorldPosition(worldPos).y;
@@ -67,6 +67,20 @@ describe("m-element-socket", () => {
     await takeAndCompareScreenshot(page);
     expect(xPos).toBeLessThan(0.01);
     expect(yPos).toBeLessThan(0.01);
+    expect(zPos).toBeLessThan(0.01);
+
+    await clickElement(page, "m-cube");
+    // socketed m-cube position should match the head bone position
+    [xPos, yPos, zPos] = await page.evaluate(() => {
+      const cube = document.getElementById("socketed-cube") as any;
+      const worldPos = cube.getContainer().position.clone();
+      const xPos = cube.getContainer().getWorldPosition(worldPos).x;
+      const yPos = cube.getContainer().getWorldPosition(worldPos).y;
+      const zPos = cube.getContainer().getWorldPosition(worldPos).z;
+      return [xPos, yPos, zPos];
+    });
+    expect(xPos).toBeLessThan(0.01);
+    expect(Math.abs(yPos - 7.978)).toBeLessThan(0.01);
     expect(zPos).toBeLessThan(0.01);
 
     await page.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -25331,7 +25331,7 @@
         "typedoc": "^0.24.8"
       },
       "devDependencies": {
-        "@types/libxmljs": "^0.18.8",
+        "@types/libxmljs": "^0.18.12",
         "xml-js": "1.6.11"
       }
     },

--- a/packages/mml-web/src/elements/Model.ts
+++ b/packages/mml-web/src/elements/Model.ts
@@ -33,13 +33,18 @@ export class Model extends TransformableElement {
     castShadows: defaultModelCastShadows,
   };
 
+  public isModel = true;
   private static modelLoader = new ModelLoader();
   protected gltfScene: THREE.Object3D | null = null;
+  protected gtlfSceneBones = new Map<string, THREE.Bone>();
   private animationGroup: THREE.AnimationObjectGroup = new THREE.AnimationObjectGroup();
   private animationMixer: THREE.AnimationMixer = new THREE.AnimationMixer(this.animationGroup);
   private documentTimeTickListener: null | { remove: () => void } = null;
 
-  private currentAnimation: THREE.AnimationClip | null = null;
+  private attachments = new Set<Model>();
+  private socketChildrenByBone = new Map<string, Set<MElement>>();
+
+  private currentAnimationClip: THREE.AnimationClip | null = null;
   private currentAnimationAction: THREE.AnimationAction | null = null;
   private collideableHelper = new CollideableHelper(this);
   private latestAnimPromise: Promise<GLTF> | null = null;
@@ -51,8 +56,6 @@ export class Model extends TransformableElement {
   private animLoadingInstanceManager = new LoadingInstanceManager(
     `${(this.constructor as typeof Model).tagName}.anim`,
   );
-
-  private socketChildrenByBone = new Map<string, Set<MElement>>();
 
   private static attributeHandler = new AttributeHandler<Model>({
     src: (instance, newValue) => {
@@ -85,42 +88,39 @@ export class Model extends TransformableElement {
     },
   });
 
-  private playAnimation(anim: THREE.AnimationClip) {
-    this.currentAnimation = anim;
-    if (this.gltfScene) {
-      this.animationGroup.remove(this.gltfScene);
-    }
-    this.animationMixer.stopAllAction();
-    const action = this.animationMixer.clipAction(this.currentAnimation);
-    action.play();
-    this.currentAnimationAction = action;
-    if (this.gltfScene) {
-      this.animationGroup.add(this.gltfScene);
-    }
+  public disableSockets() {
+    // Remove the socketed children from parent (so that the model doesn't contain any other bones / animatable properties)
+    this.socketChildrenByBone.forEach((children) => {
+      children.forEach((child) => {
+        child.getContainer().removeFromParent();
+      });
+    });
   }
 
-  private findBoneByName(boneName: string): THREE.Bone | undefined {
-    let targetBone;
-    this.gltfScene?.traverse((object) => {
-      if (object instanceof THREE.Bone && object.name === boneName) {
-        targetBone = object;
-      }
+  public restoreSockets() {
+    // Add the socketed children back to the parent
+    this.socketChildrenByBone.forEach((children, boneName) => {
+      const bone = this.gtlfSceneBones.get(boneName);
+      children.forEach((child) => {
+        if (bone) {
+          bone.add(child.getContainer());
+        } else {
+          this.getContainer().add(child.getContainer());
+        }
+      });
     });
-    return targetBone;
   }
 
   public registerSocketChild(child: TransformableElement, socketName: string): void {
     let children = this.socketChildrenByBone.get(socketName);
-    if (socketName.trim()) {
-      if (!children) {
-        children = new Set<MElement>();
-        this.socketChildrenByBone.set(socketName, children);
-      }
-      children.add(child);
+    if (!children) {
+      children = new Set<MElement>();
+      this.socketChildrenByBone.set(socketName, children);
     }
+    children.add(child);
 
     if (this.gltfScene) {
-      const bone = this.findBoneByName(socketName);
+      const bone = this.gtlfSceneBones.get(socketName);
       if (bone) {
         bone.add(child.getContainer());
       } else {
@@ -133,7 +133,6 @@ export class Model extends TransformableElement {
     const socketChildren = this.socketChildrenByBone.get(socketName);
     if (socketChildren) {
       socketChildren.delete(child);
-      child.getContainer().parent?.remove(child.getContainer());
       this.getContainer().add(child.getContainer());
       if (socketChildren.size === 0) {
         this.socketChildrenByBone.delete(socketName);
@@ -149,13 +148,21 @@ export class Model extends TransformableElement {
     });
   }
 
-  public registerAttachment(attachment: THREE.Object3D) {
-    this.animationGroup.add(attachment);
-    this.updateAnimation(this.getDocumentTime() || 0);
+  public registerAttachment(attachment: Model) {
+    console.trace("registerAttachment");
+    this.attachments.add(attachment);
+    // Temporarily remove the sockets from the attachment so that they don't get animated
+    attachment.disableSockets();
+    this.animationGroup.add(attachment.gltfScene);
+    // Restore the sockets after adding the attachment to the animation group
+    attachment.restoreSockets();
+    this.updateAnimation(this.getDocumentTime() || 0, true);
   }
 
-  public unregisterAttachment(attachment: THREE.Object3D) {
-    this.animationGroup.remove(attachment);
+  public unregisterAttachment(attachment: Model) {
+    console.trace("unregisterAttachment");
+    this.attachments.delete(attachment);
+    this.animationGroup.remove(attachment.gltfScene);
   }
 
   static get observedAttributes(): Array<string> {
@@ -185,7 +192,11 @@ export class Model extends TransformableElement {
       this.gltfScene.removeFromParent();
       Model.disposeOfGroup(this.gltfScene);
       this.gltfScene = null;
-      this.registeredParentAttachment = null;
+      this.gtlfSceneBones.clear();
+      if (this.registeredParentAttachment) {
+        this.registeredParentAttachment.unregisterAttachment(this);
+        this.registeredParentAttachment = null;
+      }
       this.onModelLoadComplete();
     }
     if (!this.props.src) {
@@ -224,18 +235,26 @@ export class Model extends TransformableElement {
         });
         this.latestSrcModelPromise = null;
         this.gltfScene = result.scene;
+        this.gtlfSceneBones = new Map<string, THREE.Bone>();
+        this.gltfScene.traverse((object) => {
+          if (object instanceof THREE.Bone) {
+            this.gtlfSceneBones.set(object.name, object);
+          }
+        });
         if (this.gltfScene) {
           this.container.add(this.gltfScene);
           this.collideableHelper.updateCollider(this.gltfScene);
 
           const parent = this.parentElement;
           if (parent instanceof Model) {
-            parent.registerAttachment(this.gltfScene);
-            this.registeredParentAttachment = parent;
+            if (!this.latestAnimPromise && !this.currentAnimationClip) {
+              parent.registerAttachment(this);
+              this.registeredParentAttachment = parent;
+            }
           }
 
-          if (this.currentAnimation) {
-            this.playAnimation(this.currentAnimation);
+          if (this.currentAnimationClip) {
+            this.playAnimation(this.currentAnimationClip);
           }
         }
         this.onModelLoadComplete();
@@ -247,28 +266,61 @@ export class Model extends TransformableElement {
       });
   }
 
+  private resetAnimationMixer() {
+    // Replace the animation group to release the old animations
+    this.animationMixer.stopAllAction();
+    this.animationGroup = new THREE.AnimationObjectGroup();
+    this.animationMixer = new THREE.AnimationMixer(this.animationGroup);
+  }
+
+  private playAnimation(anim: THREE.AnimationClip) {
+    this.currentAnimationClip = anim;
+    this.resetAnimationMixer();
+    if (this.gltfScene) {
+      this.disableSockets();
+      this.animationGroup.add(this.gltfScene);
+    }
+    for (const animationAttachment of this.attachments) {
+      animationAttachment.disableSockets();
+      this.animationGroup.add(animationAttachment.gltfScene);
+    }
+    const action = this.animationMixer.clipAction(this.currentAnimationClip);
+    action.play();
+    if (this.gltfScene) {
+      this.restoreSockets();
+    }
+    for (const animationAttachment of this.attachments) {
+      animationAttachment.restoreSockets();
+    }
+    this.currentAnimationAction = action;
+  }
+
   private setAnim(newValue: string | null) {
+    console.trace("setAnim", newValue, this.registeredParentAttachment !== null);
     this.props.anim = (newValue || "").trim();
+
+    this.resetAnimationMixer();
+    this.currentAnimationAction = null;
+    this.currentAnimationClip = null;
+
     if (!this.props.anim) {
-      if (this.currentAnimationAction) {
-        if (this.gltfScene) {
-          this.animationMixer.uncacheRoot(this.gltfScene);
-        }
-        this.animationMixer.stopAllAction();
-      }
       this.latestAnimPromise = null;
-      this.currentAnimationAction = null;
-      this.currentAnimation = null;
       this.animLoadingInstanceManager.abortIfLoading();
+
+      // If the animation is removed then the model can be added to the parent attachment if the model is loaded
       if (this.gltfScene) {
-        this.animationGroup.remove(this.gltfScene);
+        const parent = this.parentElement;
+        if (parent instanceof Model) {
+          parent.registerAttachment(this);
+          this.registeredParentAttachment = parent;
+        }
       }
       return;
     }
 
-    if (this.currentAnimationAction !== null) {
-      this.animationMixer.stopAllAction();
-      this.currentAnimationAction = null;
+    if (this.registeredParentAttachment) {
+      this.registeredParentAttachment.unregisterAttachment(this);
+      this.registeredParentAttachment = null;
     }
 
     if (!this.isConnected) {
@@ -323,27 +375,40 @@ export class Model extends TransformableElement {
     }
     this.collideableHelper.removeColliders();
     if (this.gltfScene && this.registeredParentAttachment) {
-      this.registeredParentAttachment.unregisterAttachment(this.gltfScene);
+      this.registeredParentAttachment.unregisterAttachment(this);
       this.registeredParentAttachment = null;
     }
     if (this.gltfScene) {
       this.gltfScene.removeFromParent();
       Model.disposeOfGroup(this.gltfScene);
       this.gltfScene = null;
+      this.gtlfSceneBones.clear();
     }
     this.srcLoadingInstanceManager.dispose();
     this.animLoadingInstanceManager.dispose();
     super.disconnectedCallback();
   }
 
-  private updateAnimation(docTimeMs: number) {
-    if (this.currentAnimation) {
-      if (!this.props.animEnabled) {
-        this.animationMixer.stopAllAction();
+  private triggerSocketedChildrenTransformed() {
+    // Socketed children need to be updated when the animation is updated as their position may have updated
+    this.socketChildrenByBone.forEach((children) => {
+      children.forEach((child) => {
+        if (child instanceof TransformableElement) {
+          child.parentTransformed();
+        }
+      });
+    });
+  }
+
+  private updateAnimation(docTimeMs: number, force: boolean = false) {
+    if (this.currentAnimationClip) {
+      if (!this.props.animEnabled && this.currentAnimationAction) {
+        this.resetAnimationMixer();
         this.currentAnimationAction = null;
+        this.triggerSocketedChildrenTransformed();
       } else {
         if (!this.currentAnimationAction) {
-          this.currentAnimationAction = this.animationMixer.clipAction(this.currentAnimation);
+          this.currentAnimationAction = this.animationMixer.clipAction(this.currentAnimationClip);
           this.currentAnimationAction.play();
         }
         let animationTimeMs = docTimeMs - this.props.animStartTime;
@@ -355,15 +420,19 @@ export class Model extends TransformableElement {
           }
         }
 
-        if (this.currentAnimation !== null) {
+        if (this.currentAnimationClip !== null) {
           if (!this.props.animLoop) {
-            if (animationTimeMs > this.currentAnimation.duration * 1000) {
-              animationTimeMs = this.currentAnimation.duration * 1000;
+            if (animationTimeMs > this.currentAnimationClip.duration * 1000) {
+              animationTimeMs = this.currentAnimationClip.duration * 1000;
             }
           }
         }
 
+        if (force) {
+          this.animationMixer.setTime((animationTimeMs + 1) / 1000);
+        }
         this.animationMixer.setTime(animationTimeMs / 1000);
+        this.triggerSocketedChildrenTransformed();
       }
     }
   }
@@ -373,7 +442,7 @@ export class Model extends TransformableElement {
   }
 
   public getCurrentAnimation(): THREE.AnimationClip | null {
-    return this.currentAnimation;
+    return this.currentAnimationClip;
   }
 
   async asyncLoadSourceAsset(

--- a/packages/mml-web/src/elements/TransformableElement.ts
+++ b/packages/mml-web/src/elements/TransformableElement.ts
@@ -21,13 +21,13 @@ export abstract class TransformableElement extends MElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-    if (this.socketName) {
+    if (this.socketName !== null) {
       this.registerWithParentModel(this.socketName);
     }
   }
 
   disconnectedCallback(): void {
-    if (this.socketName) {
+    if (this.socketName !== null) {
       this.unregisterFromParentModel(this.socketName);
     }
     super.disconnectedCallback();
@@ -140,7 +140,7 @@ export abstract class TransformableElement extends MElement {
       instance.container.visible = parseBoolAttribute(newValue, true);
     },
     socket: (instance, newValue) => {
-      instance.handleSocketChange(newValue as string);
+      instance.handleSocketChange(newValue);
     },
   });
 
@@ -179,27 +179,29 @@ export abstract class TransformableElement extends MElement {
     return new THREE.Box3().setFromObject(this.container);
   }
 
-  private handleSocketChange(socketName: string): void {
+  private handleSocketChange(socketName: string | null): void {
     if (this.isConnected && this.socketName !== socketName) {
-      if (this.socketName) {
+      if (this.socketName !== null) {
         this.unregisterFromParentModel(this.socketName);
       }
       this.socketName = socketName;
-      this.registerWithParentModel(socketName);
+      if (socketName !== null) {
+        this.registerWithParentModel(socketName);
+      }
     } else {
       this.socketName = socketName;
     }
   }
 
   private registerWithParentModel(socketName: string): void {
-    if (this.parentElement?.tagName.toLocaleLowerCase() === "m-character") {
+    if ((this.parentElement as Model | undefined)?.isModel) {
       const parentModel = this.parentElement as Model;
       parentModel.registerSocketChild(this, socketName);
     }
   }
 
   private unregisterFromParentModel(socketName: string): void {
-    if (this.parentElement?.tagName.toLocaleLowerCase() === "m-character") {
+    if ((this.parentElement as Model | undefined)?.isModel) {
       const parentModel = this.parentElement as Model;
       parentModel.unregisterSocketChild(this, socketName);
     }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -21,7 +21,7 @@
     "typedoc": "^0.24.8"
   },
   "devDependencies": {
-    "@types/libxmljs": "^0.18.8",
+    "@types/libxmljs": "^0.18.12",
     "xml-js": "1.6.11"
   }
 }

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -173,7 +173,7 @@
     <xs:attribute name="socket" type="xs:string">
       <xs:annotation>
         <xs:documentation>
-          The string correspondent to a bone name of the element's parent skeletal mesh that this element will be attached to. If not specified, the element will be attached to its parent's origin.
+          The name of a bone in the parent element's skeletal mesh to which this element will be attached. If not specified, the element will attach to the origin of its parent.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -170,6 +170,13 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="socket" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          The string correspondent to a bone name of the element's parent skeletal mesh that this element will be attached to. If not specified, the element will be attached to its parent's origin.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:attributeGroup>
 
   <xs:attributeGroup name="shadows">


### PR DESCRIPTION
Resolves #145 

This PR aims to provide support for any `TransformableElement` to be a child of an `m-character` tag while being attached to the bone of the `m-character`'s skeletal mesh that corresponds to the string passed as the `socket` attribute.

---

**What kind of changes does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
