### PR TITLE
Fixed m-video enabled attribute reusability bug #153

### DIFF
--- a/packages/mml-web/src/elements/Video.ts
+++ b/packages/mml-web/src/elements/Video.ts
@@ -235,16 +235,15 @@ export class Video extends TransformableElement {
       this.container.add(audio);
     }
 
-    const tag = this.loadedVideoState.video;
     if (!this.props.enabled) {
-      tag.pause();
-      this.mesh.material = disabledVideoMaterial;
+      this.clearSource();
       return;
     }
 
     if (!this.props.src) {
       this.clearSource();
     } else {
+      const tag = this.loadedVideoState.video;
       // Muted allows autoplay immediately without the user needing to interact with the document
       // Video will be unmuted when the audiocontext is available
       tag.muted = true;


### PR DESCRIPTION
Fixes #153 

This PR fixes an issue where if the `enabled` attribute of an `m-video` was set to `false`, setting it back to `true` would not bring the video back as the material would not be assigned back to the mesh.

The fix also fixes a related issue where setting `enabled="false"` would not actually stop the video from playing sound.

The change to fix both issues is to actually disable the current content completely and then re-enable it when `enabled="false"` is removed.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
