### PR TITLE
adds a 'cast-shadow' attribute to m-light to toggle shadow casting

### DIFF
--- a/packages/mml-web/src/elements/Light.ts
+++ b/packages/mml-web/src/elements/Light.ts
@@ -27,6 +27,7 @@ const defaultLightAngle = 45;
 const defaultLightEnabled = true;
 const defaultLightDebug = false;
 const defaultLightDistance = 0;
+const defaultLightCastShadow = true;
 const defaultLightType = lightTypes.spotlight;
 
 export class Light extends TransformableElement {
@@ -62,6 +63,7 @@ export class Light extends TransformableElement {
     enabled: defaultLightEnabled,
     angleDeg: defaultLightAngle,
     distance: defaultLightDistance,
+    castShadow: defaultLightCastShadow,
     debug: defaultLightDebug,
     type: defaultLightType as lightTypes,
   };
@@ -101,6 +103,10 @@ export class Light extends TransformableElement {
       } else if (instance.light instanceof THREE.PointLight) {
         (instance.light as THREE.PointLight).distance = instance.props.distance;
       }
+    },
+    "cast-shadow": (instance, newValue) => {
+      instance.props.castShadow = parseBoolAttribute(newValue, defaultLightCastShadow);
+      instance.light.castShadow = instance.props.castShadow;
     },
     debug: (instance, newValue) => {
       instance.props.debug = parseBoolAttribute(newValue, defaultLightDebug);
@@ -212,7 +218,7 @@ export class Light extends TransformableElement {
     }
 
     if (this.light.shadow) {
-      this.light.castShadow = true;
+      this.light.castShadow = this.props.castShadow;
       this.light.shadow.mapSize.width = 512;
       this.light.shadow.mapSize.height = 512;
       if (this.light.shadow.camera instanceof THREE.PerspectiveCamera) {

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -562,6 +562,13 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="cast-shadow" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether the light cast shadows (true) or not (false). Default value is true.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
           <xs:attribute name="type">
             <xs:simpleType>
               <xs:restriction base="xs:token">


### PR DESCRIPTION
This PR implements a `cast-shadow` boolean attribute to the `<m-light>` tag to allow the user to enable (default) or disable shadow casting for the `m-lights` in an MML document.

MML uses ThreeJS on `mml-web`, and ThreeJS uses shadow maps by default. That means having more than 15 lights casting shadows on a scene will likely exceed the number of texture units available for the WebGL context. Even when not exceeding the limit, a high number of shadow-casting lights with shadow maps impose a brutal performance impact (as every light casting shadows must draw every object in the scene from its own perspective to draw the shadows, and finally the renderer needs an extra draw call to blend all the shadow maps).

---

**What kind of changes does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
