### PR TITLE
m-attr-lerp #165

### DIFF
--- a/e2e-tests/src/attr-lerp.html
+++ b/e2e-tests/src/attr-lerp.html
@@ -1,0 +1,76 @@
+<m-plane color="yellow" width="15" height="15" rx="-90"></m-plane>
+<m-light type="point" intensity="900" x="10" y="10" z="10"></m-light>
+
+<m-label width="5" y="1" rx="-45" z="3" content="This test tests snapshots of the state at intervals of document time. The document time is overridden in e2e tests"></m-label>
+
+<m-group id="timeline" y="0.25">
+  <m-cube width="15" height="0.25" depth="0.1" color="black"></m-cube>
+  <m-cube width="1" x="-5.6" y="0.25" height="0.25" depth="0.1" z="0.1" color="green"></m-cube>
+  <m-cube width="1" height="0.25" depth="0.1" z="0.1" color="red">
+    <m-attr-anim attr="x" start="-7" end="7" loop="true" duration="10000"></m-attr-anim>
+  </m-cube>
+</m-group>
+
+<m-group x="0" y="2">
+  <m-label content="independent attributes" width="5" y="0.75" alignment="center" height="0.5"></m-label>
+  <!-- Two independent attributes -->
+  <m-cube width="5" x="-2.5" height="1" z="-0.1" depth="0.1" color="red"></m-cube>
+  <m-cube width="5" x="2.5" height="1" z="-0.1" depth="0.1" color="green"></m-cube>
+  <m-cube x="-4.25" depth="0.1" height="0.5" color="white" id="two-independent-attributes" onclick="this.setAttribute('x','4.25'); this.setAttribute('height','0.1');">
+    <m-attr-lerp attr="x" duration="4000"></m-attr-lerp>
+    <m-attr-lerp attr="height" duration="2000"></m-attr-lerp>
+  </m-cube>
+</m-group>
+
+<m-group x="0" y="3.75">
+  <m-label content="combined attributes - shadowed" width="5" y="0.75" alignment="center" height="0.5"></m-label>
+  <!-- Combined attributes with an unused later sibling that is overridden -->
+  <m-cube width="5" x="-2.5" height="1" z="-0.1" depth="0.1" color="red"></m-cube>
+  <m-cube width="5" x="2.5" height="1" z="-0.1" depth="0.1" color="green"></m-cube>
+  <m-cube x="-4.25" depth="0.1" height="0.5" color="white" id="combined-attributes-shadowed" onclick="this.setAttribute('x','4.25'); this.setAttribute('height','0.1');">
+    <m-attr-lerp attr="x,height" duration="4000"></m-attr-lerp>
+    <m-attr-lerp attr="x" duration="2000"></m-attr-lerp>
+  </m-cube>
+</m-group>
+
+<m-group x="0" y="5.5">
+  <m-label content="combined attributes - overridden" width="5" y="0.75" alignment="center" height="0.5"></m-label>
+  <!-- Combined attributes, but with an earlier sibling that overrides the duration -->
+  <m-cube width="5" x="-2.5" height="1" z="-0.1" depth="0.1" color="red"></m-cube>
+  <m-cube width="5" x="2.5" height="1" z="-0.1" depth="0.1" color="green"></m-cube>
+  <m-cube x="-4.25" depth="0.1" height="0.5" color="white" id="combined-attributes-overridden" onclick="this.setAttribute('x','4.25'); this.setAttribute('height','0.1');">
+    <m-attr-lerp attr="x" duration="2000"></m-attr-lerp>
+    <m-attr-lerp attr="x,height" duration="4000"></m-attr-lerp>
+  </m-cube>
+</m-group>
+
+<m-group x="0" y="7.25">
+  <m-label content="all attributes" width="5" y="0.75" alignment="center" height="0.5"></m-label>
+  <!-- Explicitly specifying "all" attributes -->
+  <m-cube width="5" x="-2.5" height="1" z="-0.1" depth="0.1" color="red"></m-cube>
+  <m-cube width="5" x="2.5" height="1" z="-0.1" depth="0.1" color="green"></m-cube>
+  <m-cube x="-4.25" depth="0.1" height="0.5" color="white" id="all-attributes" onclick="this.setAttribute('x','4.25'); this.setAttribute('height','0.1');">
+    <m-attr-lerp attr="all" duration="2000"></m-attr-lerp>
+  </m-cube>
+</m-group>
+
+<m-group x="0" y="9">
+  <m-label content="all attributes (default)" width="5" y="0.75" alignment="center" height="0.5"></m-label>
+  <!-- Default behaviour of not specifying "attr" is to have all attributes lerped -->
+  <m-cube width="5" x="-2.5" height="1" z="-0.1" depth="0.1" color="red"></m-cube>
+  <m-cube width="5" x="2.5" height="1" z="-0.1" depth="0.1" color="green"></m-cube>
+  <m-cube x="-4.25" depth="0.1" height="0.5" color="white" id="all-attributes-default" onclick="this.setAttribute('x','4.25'); this.setAttribute('height','0.1');">
+    <m-attr-lerp duration="2000"></m-attr-lerp>
+  </m-cube>
+</m-group>
+
+
+<m-group x="0" y="10.75">
+  <m-label content="no attributes" width="5" y="0.75" alignment="center" height="0.5"></m-label>
+  <!-- Explicitly setting "attr" to empty (no lerping) -->
+  <m-cube width="5" x="-2.5" height="1" z="-0.1" depth="0.1" color="red"></m-cube>
+  <m-cube width="5" x="2.5" height="1" z="-0.1" depth="0.1" color="green"></m-cube>
+  <m-cube x="-4.25" depth="0.1" height="0.5" color="white" id="no-attributes" onclick="this.setAttribute('x','4.25'); this.setAttribute('height','0.1');">
+    <m-attr-lerp attr="" duration="2000"></m-attr-lerp>
+  </m-cube>
+</m-group>

--- a/e2e-tests/test/__image_snapshots__/attr-lerp-test-ts-m-attr-lerp-lerping-is-applied-according-to-attributes-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/attr-lerp-test-ts-m-attr-lerp-lerping-is-applied-according-to-attributes-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da72efcefe3be5c718ef692ca1e9c49173afe48e179e38fa418552f224c57aee
+size 128967

--- a/e2e-tests/test/__image_snapshots__/attr-lerp-test-ts-m-attr-lerp-lerping-is-applied-according-to-attributes-2-snap.png
+++ b/e2e-tests/test/__image_snapshots__/attr-lerp-test-ts-m-attr-lerp-lerping-is-applied-according-to-attributes-2-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:585d124571fded7dcd7a9771f1cc8e9bf1ab87eeabccf45a5ddf8b9c2d0a41a5
+size 128586

--- a/e2e-tests/test/__image_snapshots__/attr-lerp-test-ts-m-attr-lerp-lerping-is-applied-according-to-attributes-3-snap.png
+++ b/e2e-tests/test/__image_snapshots__/attr-lerp-test-ts-m-attr-lerp-lerping-is-applied-according-to-attributes-3-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e2cfd902ed731c352624739446ba3265d96717f42b36a5fbf2147403c356038
+size 128710

--- a/e2e-tests/test/attr-lerp.test.ts
+++ b/e2e-tests/test/attr-lerp.test.ts
@@ -1,0 +1,83 @@
+import { clickElement, setDocumentTime, takeAndCompareScreenshot } from "./testing-utils";
+
+type ExpectedStates = { [key: string]: { x: number; height: number } };
+
+describe("m-attr-lerp", () => {
+  test("lerping is applied according to attributes", async () => {
+    const page = await __BROWSER_GLOBAL__.newPage();
+
+    await page.setViewport({ width: 1024, height: 1024 });
+
+    await page.goto("http://localhost:7079/attr-lerp.html/reset");
+
+    await page.waitForSelector("m-attr-lerp[attr='x']");
+
+    async function testExpectedStates(expectedStates: ExpectedStates) {
+      for (const [id, expected] of Object.entries(expectedStates)) {
+        const actualX = await page.evaluate((id) => {
+          return (document.querySelector(`#${id}`) as any).getContainer().position.x;
+        }, id);
+
+        const actualHeight = await page.evaluate((id) => {
+          return (document.querySelector(`#${id}`) as any).getCube().scale.y;
+        }, id);
+
+        expect(`${id}: x: ${actualX} height: ${actualHeight}`).toEqual(
+          `${id}: x: ${expected.x} height: ${expected.height}`,
+        );
+      }
+    }
+
+    // Set the document time to 0 to use as a reference point for the start of the lerping
+    await setDocumentTime(page, 0);
+
+    await testExpectedStates({
+      "two-independent-attributes": { x: -4.25, height: 0.5 },
+      "combined-attributes-shadowed": { x: -4.25, height: 0.5 },
+      "combined-attributes-overridden": { x: -4.25, height: 0.5 },
+      "all-attributes": { x: -4.25, height: 0.5 },
+      "all-attributes-default": { x: -4.25, height: 0.5 },
+      "no-attributes": { x: -4.25, height: 0.5 },
+    });
+
+    await takeAndCompareScreenshot(page);
+
+    // Click all of the cubes to trigger the lerping
+    await clickElement(page, "#two-independent-attributes");
+    await clickElement(page, "#combined-attributes-shadowed");
+    await clickElement(page, "#combined-attributes-overridden");
+    await clickElement(page, "#all-attributes");
+    await clickElement(page, "#all-attributes-default");
+    await clickElement(page, "#no-attributes");
+
+    // Set the document time to 1000 to check the lerping
+    await setDocumentTime(page, 1000);
+
+    await testExpectedStates({
+      "two-independent-attributes": { x: -2.125, height: 0.3 },
+      "combined-attributes-shadowed": { x: -2.125, height: 0.4 },
+      "combined-attributes-overridden": { x: 0, height: 0.4 },
+      "all-attributes": { x: 0, height: 0.3 },
+      "all-attributes-default": { x: 0, height: 0.3 },
+      "no-attributes": { x: 4.25, height: 0.1 },
+    });
+
+    await takeAndCompareScreenshot(page);
+
+    // Set the document time to 1000 to check the lerping
+    await setDocumentTime(page, 5000);
+
+    await testExpectedStates({
+      "two-independent-attributes": { x: 4.25, height: 0.1 },
+      "combined-attributes-shadowed": { x: 4.25, height: 0.1 },
+      "combined-attributes-overridden": { x: 4.25, height: 0.1 },
+      "all-attributes": { x: 4.25, height: 0.1 },
+      "all-attributes-default": { x: 4.25, height: 0.1 },
+      "no-attributes": { x: 4.25, height: 0.1 },
+    });
+
+    await takeAndCompareScreenshot(page);
+
+    await page.close();
+  }, 60000);
+});

--- a/e2e-tests/test/testing-utils.ts
+++ b/e2e-tests/test/testing-utils.ts
@@ -49,7 +49,7 @@ export async function setDocumentTime(page: puppeteer.Page, documentTime: number
   }, documentTime);
 }
 
-export async function takeAndCompareScreenshot(page: puppeteer.Page, threshold = 0.01) {
+export async function takeAndCompareScreenshot(page: puppeteer.Page, threshold = 0.011) {
   expect(await page.screenshot()).toMatchImageSnapshot({
     failureThresholdType: "percent",
     failureThreshold: threshold,

--- a/packages/mml-web/src/MMLDocumentTimeManager.ts
+++ b/packages/mml-web/src/MMLDocumentTimeManager.ts
@@ -25,6 +25,13 @@ export class MMLDocumentTimeManager {
     return (document.timeline.currentTime as number)! - this.relativeDocumentStartTime;
   }
 
+  public getWindowTime(): number {
+    if (this.overridenDocumentTime !== null) {
+      return this.overridenDocumentTime;
+    }
+    return document.timeline.currentTime as number;
+  }
+
   public addDocumentTimeListenerCallback(cb: (time: number) => void) {
     this.documentTimeListeners.add(cb);
   }

--- a/packages/mml-web/src/elements/AttributeAnimation.ts
+++ b/packages/mml-web/src/elements/AttributeAnimation.ts
@@ -109,7 +109,7 @@ export class AttributeAnimation extends MElement {
       instance.props.pauseTime = parseFloatAttribute(newValue, defaultPauseTime);
     },
     duration: (instance, newValue) => {
-      instance.props.animDuration = parseFloatAttribute(newValue, defaultAnimDuration);
+      instance.props.animDuration = Math.max(0, parseFloatAttribute(newValue, defaultAnimDuration));
     },
   });
 

--- a/packages/mml-web/src/elements/AttributeLerp.ts
+++ b/packages/mml-web/src/elements/AttributeLerp.ts
@@ -1,0 +1,135 @@
+import * as THREE from "three";
+
+import { MElement } from "./MElement";
+import { AttributeHandler, parseFloatAttribute } from "../utils/attribute-handling";
+import { easingsByName } from "../utils/easings";
+import { OrientedBoundingBox } from "../utils/OrientedBoundingBox";
+
+const defaultAttribute: string = "all";
+const defaultEasing = "";
+const defaultLerpDuration = 1000;
+
+export class AttributeLerp extends MElement {
+  static tagName = "m-attr-lerp";
+
+  private props = {
+    attr: defaultAttribute,
+    easing: defaultEasing,
+    lerpDuration: defaultLerpDuration,
+  };
+
+  private registeredParentAttachment: MElement | null = null;
+
+  private static attributeHandler = new AttributeHandler<AttributeLerp>({
+    attr: (instance, newValue) => {
+      if (instance.registeredParentAttachment) {
+        instance.registeredParentAttachment.removeSideEffectChild(instance);
+      }
+      instance.props.attr = newValue !== null ? newValue : defaultAttribute;
+      if (instance.registeredParentAttachment) {
+        instance.registeredParentAttachment.addSideEffectChild(instance);
+      }
+    },
+    easing: (instance, newValue) => {
+      instance.props.easing = newValue || defaultEasing;
+    },
+    duration: (instance, newValue) => {
+      instance.props.lerpDuration = Math.max(0, parseFloatAttribute(newValue, defaultLerpDuration));
+    },
+  });
+
+  static get observedAttributes(): Array<string> {
+    return [...AttributeLerp.attributeHandler.getAttributes()];
+  }
+  constructor() {
+    super();
+  }
+
+  protected enable() {
+    // no-op
+  }
+
+  protected disable() {
+    // no-op
+  }
+
+  protected getContentBounds(): OrientedBoundingBox | null {
+    return null;
+  }
+
+  public getAnimatedAttributeName(): string | null {
+    return this.props.attr;
+  }
+
+  public parentTransformed(): void {
+    // no-op
+  }
+
+  public isClickable(): boolean {
+    return false;
+  }
+
+  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+    AttributeLerp.attributeHandler.handle(this, name, newValue);
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    if (this.parentElement && this.parentElement instanceof MElement) {
+      this.registeredParentAttachment = this.parentElement;
+      this.registeredParentAttachment.addSideEffectChild(this);
+    }
+  }
+
+  disconnectedCallback() {
+    if (this.registeredParentAttachment) {
+      this.registeredParentAttachment.removeSideEffectChild(this);
+    }
+    this.registeredParentAttachment = null;
+    super.disconnectedCallback();
+  }
+
+  public getColorValueForTime(
+    windowTime: number,
+    elementValueSetTime: number,
+    elementValue: THREE.Color,
+    previousValue: THREE.Color,
+  ) {
+    const ratio = this.getLerpRatio(windowTime, elementValueSetTime);
+    if (ratio >= 1) {
+      return elementValue;
+    }
+    return new THREE.Color(previousValue).lerpHSL(elementValue, ratio);
+  }
+
+  public getFloatValueForTime(
+    windowTime: number,
+    elementValueSetTime: number,
+    elementValue: number,
+    previousValue: number,
+  ) {
+    const from = previousValue;
+    const to = elementValue;
+    const ratio = this.getLerpRatio(windowTime, elementValueSetTime);
+    if (ratio >= 1) {
+      return to;
+    }
+    return from + (to - from) * ratio;
+  }
+
+  private getLerpRatio(windowTime: number, elementValueSetTime: number) {
+    const duration = this.props.lerpDuration;
+    const timePassed = (windowTime || 0) - elementValueSetTime;
+    const ratioOfTimePassed = Math.min(timePassed / duration, 1);
+    const easing = this.props.easing;
+    let ratio;
+    const easingFunction = easingsByName[easing];
+    if (easingFunction) {
+      ratio = easingFunction(ratioOfTimePassed, 0, 1, 1);
+    } else {
+      ratio = ratioOfTimePassed;
+    }
+    return ratio;
+  }
+}

--- a/packages/mml-web/src/elements/Audio.ts
+++ b/packages/mml-web/src/elements/Audio.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { PositionalAudioHelper } from "three/addons/helpers/PositionalAudioHelper.js";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -184,22 +184,12 @@ export class Audio extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.audioAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.audioAnimatedAttributeHelper.addSideEffectChild(child);
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.audioAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.audioAnimatedAttributeHelper.removeSideEffectChild(child);
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/ChatProbe.ts
+++ b/packages/mml-web/src/elements/ChatProbe.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { IMMLScene } from "../MMLScene";
@@ -87,22 +87,14 @@ export class ChatProbe extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.chatProbeAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.chatProbeAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.chatProbeAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.chatProbeAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/Cube.ts
+++ b/packages/mml-web/src/elements/Cube.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -165,22 +165,14 @@ export class Cube extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.cubeAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.cubeAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.cubeAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.cubeAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/Cylinder.ts
+++ b/packages/mml-web/src/elements/Cylinder.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -154,22 +154,14 @@ export class Cylinder extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.cylinderAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.cylinderAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.cylinderAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.cylinderAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/Image.ts
+++ b/packages/mml-web/src/elements/Image.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { LoadingInstanceManager } from "../loading/LoadingInstanceManager";
@@ -137,22 +137,14 @@ export class Image extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.imageAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.imageAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.imageAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.imageAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/Interaction.ts
+++ b/packages/mml-web/src/elements/Interaction.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { IMMLScene } from "../MMLScene";
@@ -96,22 +96,14 @@ export class Interaction extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.interactionAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.interactionAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.interactionAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.interactionAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/Label.ts
+++ b/packages/mml-web/src/elements/Label.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -185,22 +185,14 @@ export class Label extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.labelAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.labelAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.labelAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.labelAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/Light.ts
+++ b/packages/mml-web/src/elements/Light.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -151,22 +151,14 @@ export class Light extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.lightAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.lightAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.lightAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.lightAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/MElement.ts
+++ b/packages/mml-web/src/elements/MElement.ts
@@ -112,12 +112,20 @@ export abstract class MElement extends HTMLElement {
     return window.location;
   }
 
-  protected getDocumentTime(): number | null {
+  public getDocumentTime(): number | null {
     const documentTimeContextProvider = this.getDocumentTimeManager();
     if (documentTimeContextProvider) {
       return documentTimeContextProvider.getDocumentTime();
     }
     return null;
+  }
+
+  public getWindowTime(): number {
+    const documentTimeContextProvider = this.getDocumentTimeManager();
+    if (documentTimeContextProvider) {
+      return documentTimeContextProvider.getWindowTime();
+    }
+    return document.timeline.currentTime!;
   }
 
   protected getLoadingProgressManager(): LoadingProgressManager | null {

--- a/packages/mml-web/src/elements/Plane.ts
+++ b/packages/mml-web/src/elements/Plane.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -147,22 +147,14 @@ export class Plane extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.planeAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.planeAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.planeAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.planeAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/PositionProbe.ts
+++ b/packages/mml-web/src/elements/PositionProbe.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -101,22 +101,14 @@ export class PositionProbe extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.positionProbeAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.positionProbeAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.positionProbeAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.positionProbeAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/Sphere.ts
+++ b/packages/mml-web/src/elements/Sphere.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -139,22 +139,14 @@ export class Sphere extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.sphereAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.sphereAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.sphereAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.sphereAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/TransformableElement.ts
+++ b/packages/mml-web/src/elements/TransformableElement.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { Model } from "./Model";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -185,21 +185,11 @@ export abstract class TransformableElement extends MElement {
   protected abstract getContentBounds(): OrientedBoundingBox | null;
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.animatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.animatedAttributeHelper.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.animatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.animatedAttributeHelper.removeSideEffectChild(child);
   }
 
   private handleSocketChange(socketName: string | null): void {

--- a/packages/mml-web/src/elements/Video.ts
+++ b/packages/mml-web/src/elements/Video.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { AnimationType, AttributeAnimation } from "./AttributeAnimation";
+import { AnimationType } from "./AttributeAnimation";
 import { MElement } from "./MElement";
 import { TransformableElement } from "./TransformableElement";
 import { AnimatedAttributeHelper } from "../utils/AnimatedAttributeHelper";
@@ -168,22 +168,14 @@ export class Video extends TransformableElement {
   }
 
   public addSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.videoAnimatedAttributeHelper.addAnimation(child, attr);
-      }
-    }
+    this.videoAnimatedAttributeHelper.addSideEffectChild(child);
+
     super.addSideEffectChild(child);
   }
 
   public removeSideEffectChild(child: MElement): void {
-    if (child instanceof AttributeAnimation) {
-      const attr = child.getAnimatedAttributeName();
-      if (attr) {
-        this.videoAnimatedAttributeHelper.removeAnimation(child, attr);
-      }
-    }
+    this.videoAnimatedAttributeHelper.removeSideEffectChild(child);
+
     super.removeSideEffectChild(child);
   }
 

--- a/packages/mml-web/src/elements/register-custom-elements.ts
+++ b/packages/mml-web/src/elements/register-custom-elements.ts
@@ -1,4 +1,5 @@
 import { AttributeAnimation } from "./AttributeAnimation";
+import { AttributeLerp } from "./AttributeLerp";
 import { Audio } from "./Audio";
 import { Character } from "./Character";
 import { ChatProbe } from "./ChatProbe";
@@ -42,4 +43,5 @@ export function registerCustomElementsToWindow(targetWindow: Window) {
   targetWindow.customElements.define(ChatProbe.tagName, ChatProbe);
   targetWindow.customElements.define(Interaction.tagName, Interaction);
   targetWindow.customElements.define(AttributeAnimation.tagName, AttributeAnimation);
+  targetWindow.customElements.define(AttributeLerp.tagName, AttributeLerp);
 }

--- a/packages/mml-web/src/utils/AnimatedAttributeHelper.ts
+++ b/packages/mml-web/src/utils/AnimatedAttributeHelper.ts
@@ -292,7 +292,7 @@ export class AnimatedAttributeHelper {
 
       if (stale !== null) {
         updateIfChangedValue(state, stale.value);
-        break;
+        continue;
       }
 
       if (state.lerpsInOrder.length > 0) {

--- a/packages/mml-web/src/utils/AnimatedAttributeHelper.ts
+++ b/packages/mml-web/src/utils/AnimatedAttributeHelper.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 
 import { AnimationType, AttributeAnimation } from "../elements/AttributeAnimation";
+import { AttributeLerp } from "../elements/AttributeLerp";
 import { MElement } from "../elements/MElement";
 
 type AttributeTuple<T extends AnimationType> = T extends AnimationType.Number
@@ -25,8 +26,10 @@ type AnimationTypeToValueType<T extends AnimationType> = T extends AnimationType
   : THREE.Color;
 
 type AttributeState<T extends AnimationType> = {
-  type: AnimationType;
+  type: T;
+  previousValue: AnimationTypeToValueType<T> | null;
   elementValue: AnimationTypeToValueType<T> | null;
+  elementValueSetTime: number | null;
   latestValue: AnimationTypeToValueType<T> | null;
   defaultValue: AnimationTypeToValueType<T> | null;
   handler: (newValue: AnimationTypeToValueType<T> | null) => void;
@@ -36,11 +39,15 @@ type AnimationStateRecord<T extends AnimationType> = {
   config: AttributeState<T>;
   animationsInOrder: Array<AttributeAnimation>;
   animationsSet: Set<AttributeAnimation>;
+  lerpsInOrder: Array<AttributeLerp>;
+  lerpsSet: Set<AttributeLerp>;
 };
 
 function TupleToState<T extends AnimationType>(tuple: AttributeTuple<T>): AttributeState<T> {
   return {
+    previousValue: null,
     elementValue: null,
+    elementValueSetTime: null,
     type: tuple[0],
     latestValue: tuple[1],
     defaultValue: tuple[1],
@@ -62,6 +69,18 @@ function updateIfChangedValue<T extends AnimationType>(
   }
 }
 
+function isColorAttribute(
+  attributeState: AttributeState<AnimationType>,
+): attributeState is AttributeState<AnimationType.Color> {
+  return attributeState.type === AnimationType.Color;
+}
+
+function isNumberAttribute(
+  attributeState: AttributeState<AnimationType>,
+): attributeState is AttributeState<AnimationType.Number> {
+  return attributeState.type === AnimationType.Number;
+}
+
 /**
  * The AnimatedAttributeHelper is a utility class that manages the application of attribute animations to an element.
  *
@@ -75,6 +94,7 @@ export class AnimatedAttributeHelper {
     [p: string]: AnimationStateRecord<AnimationType>;
   } = {};
   private allAnimations: Set<AttributeAnimation> = new Set();
+  private allLerps: Set<AttributeLerp> = new Set();
   private documentTimeTickListener: null | { remove: () => void } = null;
 
   constructor(element: MElement, handlers: AttributeHandlerRecord) {
@@ -85,7 +105,37 @@ export class AnimatedAttributeHelper {
         config: state,
         animationsInOrder: [],
         animationsSet: new Set(),
+        lerpsInOrder: [],
+        lerpsSet: new Set(),
       };
+    }
+  }
+
+  public addSideEffectChild(child: MElement): void {
+    if (child instanceof AttributeAnimation) {
+      const attr = child.getAnimatedAttributeName();
+      if (attr) {
+        this.addAnimation(child, attr);
+      }
+    } else if (child instanceof AttributeLerp) {
+      const attr = child.getAnimatedAttributeName();
+      if (attr) {
+        this.addLerp(child, attr);
+      }
+    }
+  }
+
+  public removeSideEffectChild(child: MElement): void {
+    if (child instanceof AttributeAnimation) {
+      const attr = child.getAnimatedAttributeName();
+      if (attr) {
+        this.removeAnimation(child, attr);
+      }
+    } else if (child instanceof AttributeLerp) {
+      const attr = child.getAnimatedAttributeName();
+      if (attr) {
+        this.removeLerp(child, attr);
+      }
     }
   }
 
@@ -97,11 +147,76 @@ export class AnimatedAttributeHelper {
     if (!state) {
       return;
     }
+    state.config.previousValue = state.config.latestValue;
     state.config.elementValue = newValue;
-    if (state.animationsSet.size > 0) {
+    if (this.element.isConnected) {
+      state.config.elementValueSetTime = this.element.getWindowTime();
+    } else {
+      state.config.elementValueSetTime = null;
+    }
+    if (state.animationsSet.size > 0 || state.lerpsSet.size > 0) {
       return;
     }
     updateIfChangedValue(state, newValue);
+  }
+
+  public getAttributesForAttributeValue(attr: string): Array<string> {
+    // attr is in the format "some-attr, another-attr" or "all". Only return attributes that exist
+    if (attr === "all") {
+      return Object.keys(this.stateByAttribute);
+    }
+    return attr
+      .split(",")
+      .map((a) => a.trim())
+      .filter((a) => this.stateByAttribute[a]);
+  }
+
+  public addLerp(lerp: AttributeLerp, attributeValue: string) {
+    const attributes = this.getAttributesForAttributeValue(attributeValue);
+    for (const key of attributes) {
+      const state = this.stateByAttribute[key];
+      if (!state) {
+        return;
+      }
+      if (state.animationsSet.size === 0) {
+        // start listening to document time
+        this.documentTimeTickListener = this.element.addDocumentTimeTickListener((documentTime) => {
+          this.updateTime(documentTime);
+        });
+      }
+      this.allLerps.add(lerp);
+      state.lerpsSet.add(lerp);
+      state.lerpsInOrder = [];
+      const elementChildren = Array.from(this.element.children);
+      for (const child of elementChildren) {
+        if (state.lerpsSet.has(child as AttributeLerp)) {
+          state.lerpsInOrder.push(child as AttributeLerp);
+        }
+      }
+    }
+  }
+
+  public removeLerp(lerp: AttributeLerp, attributeValue: string) {
+    const attributes = this.getAttributesForAttributeValue(attributeValue);
+    for (const key of attributes) {
+      const state = this.stateByAttribute[key];
+      if (!state) {
+        return;
+      }
+      state.lerpsInOrder.splice(state.lerpsInOrder.indexOf(lerp), 1);
+      state.lerpsSet.delete(lerp);
+      if (state.animationsSet.size === 0) {
+        updateIfChangedValue(state, state.config.elementValue);
+      }
+      this.allLerps.delete(lerp);
+      if (this.allLerps.size === 0) {
+        // stop listening to document time
+        if (this.documentTimeTickListener) {
+          this.documentTimeTickListener.remove();
+          this.documentTimeTickListener = null;
+        }
+      }
+    }
   }
 
   public addAnimation(animation: AttributeAnimation, key: string) {
@@ -177,6 +292,39 @@ export class AnimatedAttributeHelper {
 
       if (stale !== null) {
         updateIfChangedValue(state, stale.value);
+        break;
+      }
+
+      if (state.lerpsInOrder.length > 0) {
+        const lerp = state.lerpsInOrder[0];
+        const config = state.config;
+        if (
+          config.elementValueSetTime !== null &&
+          config.previousValue !== null &&
+          config.elementValue !== null
+        ) {
+          if (isColorAttribute(config)) {
+            updateIfChangedValue(
+              state,
+              lerp.getColorValueForTime(
+                this.element.getWindowTime(),
+                config.elementValueSetTime,
+                config.elementValue,
+                config.previousValue,
+              ),
+            );
+          } else if (isNumberAttribute(config)) {
+            updateIfChangedValue(
+              state,
+              lerp.getFloatValueForTime(
+                this.element.getWindowTime(),
+                config.elementValueSetTime,
+                config.elementValue,
+                config.previousValue,
+              ),
+            );
+          }
+        }
       }
     }
   }

--- a/packages/schema-validator/test/elements/m-attr-lerp.test.ts
+++ b/packages/schema-validator/test/elements/m-attr-lerp.test.ts
@@ -1,0 +1,14 @@
+import { validateMMLDocument } from "../../src";
+
+test("<m-attr-lerp>", () => {
+  const validationErrors = validateMMLDocument(`
+<m-attr-lerp
+  id="my-attr-lerp"
+  class="some-attr-lerp-class" 
+  attr="x"
+  duration="5000"
+  easing="easeInOutSine"
+></m-attr-lerp>
+`);
+  expect(validationErrors).toBeNull();
+});

--- a/packages/schema-validator/test/exhaustive-tags.test.ts
+++ b/packages/schema-validator/test/exhaustive-tags.test.ts
@@ -15,6 +15,7 @@ test("exhaustive tags", () => {
   <m-position-probe></m-position-probe>
   <m-chat-probe></m-chat-probe>
   <m-attr-anim></m-attr-anim>
+  <m-attr-lerp></m-attr-lerp>
   <m-frame></m-frame>
   <m-label></m-label>
   <m-group></m-group>

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -363,6 +363,7 @@
       <xs:element ref="m-chat-probe"/>
       <xs:element ref="m-interaction"/>
       <xs:element ref="m-attr-anim"/>
+      <xs:element ref="m-attr-lerp"/>
       <xs:element ref="m-frame"/>
       <xs:element ref="m-cylinder"/>
       <xs:element ref="m-group"/>
@@ -1407,6 +1408,76 @@
                 If `ping-pong` is `true` then the `ping-pong-delay` attribute specifies the time in milliseconds that the animation should pause at the `start` and `end` values. This time is part of the overall `duration` (it does not extend the time taken), and as the `ping-pong-delay` is the time held at both `start` and `end`, the total time where the value is held is double the value of `ping-pong-delay`. Default value is 0.
               </xs:documentation>
             </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="m-attr-lerp">
+    <xs:annotation>
+      <xs:documentation>
+        The `m-attr-lerp` element is used to describe time-transitioned changes to element attributes.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="MMLContent">
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attribute name="attr" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                The attribute(s) of the parent element that this lerp will animate. Multiple attributes can be specified by separating them with a comma. A value of "all" applies this lerp to all attributes.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="duration" type="xs:integer">
+            <xs:annotation>
+              <xs:documentation>
+                The duration of the lerp in milliseconds. This is the time taken to go from the previous value of the attribute to the latest value. Default value is 1000 (1 second).
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="easing">
+            <xs:annotation>
+              <xs:documentation>
+                The name of the easing function to apply to the lerp ratio to achieve effects such as smooth animations. If the attribute is not specified or is empty the lerp will be linear.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="easeInQuad"/>
+                <xs:enumeration value="easeOutQuad"/>
+                <xs:enumeration value="easeInOutQuad"/>
+                <xs:enumeration value="easeInCubic"/>
+                <xs:enumeration value="easeOutCubic"/>
+                <xs:enumeration value="easeInOutCubic"/>
+                <xs:enumeration value="easeInQuart"/>
+                <xs:enumeration value="easeOutQuart"/>
+                <xs:enumeration value="easeInOutQuart"/>
+                <xs:enumeration value="easeInQuint"/>
+                <xs:enumeration value="easeOutQuint"/>
+                <xs:enumeration value="easeInOutQuint"/>
+                <xs:enumeration value="easeInSine"/>
+                <xs:enumeration value="easeOutSine"/>
+                <xs:enumeration value="easeInOutSine"/>
+                <xs:enumeration value="easeInExpo"/>
+                <xs:enumeration value="easeOutExpo"/>
+                <xs:enumeration value="easeInOutExpo"/>
+                <xs:enumeration value="easeInCirc"/>
+                <xs:enumeration value="easeOutCirc"/>
+                <xs:enumeration value="easeInOutCirc"/>
+                <xs:enumeration value="easeInElastic"/>
+                <xs:enumeration value="easeOutElastic"/>
+                <xs:enumeration value="easeInOutElastic"/>
+                <xs:enumeration value="easeInBack"/>
+                <xs:enumeration value="easeOutBack"/>
+                <xs:enumeration value="easeInOutBack"/>
+                <xs:enumeration value="easeInBounce"/>
+                <xs:enumeration value="easeOutBounce"/>
+                <xs:enumeration value="easeInOutBounce"/>
+              </xs:restriction>
+            </xs:simpleType>
           </xs:attribute>
         </xs:extension>
       </xs:complexContent>


### PR DESCRIPTION
Resolves #165 

This PR adds a new element, `m-attr-lerp` that allows smoothly lerping between element attribute values similarly to `m-attr-anim`, but without having to specify document-time based timings and explicit `start` and `end` attributes.

Example usage:

```html
<m-cube x="-3" onclick="this.setAttribute('x','3');">
  <m-attr-lerp attr="x" duration="2000" easing="easeInOutCubic"></m-attr-lerp>
</m-cube>
```

The "attr" attribute also allows specifying multiple comma-separated attributes or `all` to apply to all attributes at once (which is also the default if `attr` is not provided).

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
