### PR TITLE
Fix memory leak in m-frame loading progress (#178)

### DIFF
--- a/packages/mml-web/src/elements/Model.ts
+++ b/packages/mml-web/src/elements/Model.ts
@@ -435,6 +435,7 @@ export class Model extends TransformableElement {
       Model.disposeOfGroup(this.loadedState.group);
       this.loadedState = null;
     }
+    this.latestSrcModelPromise = null;
     this.srcLoadingInstanceManager.dispose();
     this.animLoadingInstanceManager.dispose();
     this.clearDebugVisualisation();

--- a/packages/mml-web/src/utils/CollideableHelper.ts
+++ b/packages/mml-web/src/utils/CollideableHelper.ts
@@ -119,6 +119,8 @@ export class CollideableHelper {
 
     scene.removeCollider?.(this.collider, this.element);
 
+    this.collider = null;
+
     this.scene = null;
   }
 


### PR DESCRIPTION
Fixes #178.

The removal of loading progress of static `m-frame`s was being reported to the wrong `LoadingProgressManager`. It should have been being reported to the parent `LoadingProgressManager`, but was instead reported to its own. This meant that the parent `LoadingProgressManager` was retaining a reference to the `m-frame` element which was preventing it from being garbage collected.

There are also two minor drive-by fixes that were found during investigation that prevent holding references to previous instance data.

cc @tbergmueller

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
