### PR TITLE
adds the emissive attribute to the m-video element

### DIFF
--- a/e2e-tests/src/m-video-emissive-test.html
+++ b/e2e-tests/src/m-video-emissive-test.html
@@ -1,0 +1,23 @@
+<m-group z="-7.5" x="-9" y="8">
+  <m-video width="8" src="/assets/timestamp-video.mp4" start-time="0" pause-time="5000"></m-video>
+</m-group>
+
+<m-group z="-7.5" x="0" y="8">
+  <m-video width="8" height="3" src="/assets/timestamp-video.mp4" start-time="1000" pause-time="5000" emissive="0"></m-video>
+</m-group>
+
+<m-group z="-7.5" x="9" y="8">
+  <m-video height="4" src="/assets/timestamp-video.mp4" start-time="-5000" pause-time="5000" emissive="1"></m-video>
+</m-group>
+
+<m-group z="-7.5" x="-9" y="2.5">
+  <m-video width="8" src="/assets/timestamp-video.mp4" start-time="0" pause-time="5000" emissive="0.1"></m-video>
+</m-group>
+
+<m-group z="-7.5" x="0" y="2.5">
+  <m-video width="8" height="3" src="/assets/timestamp-video.mp4" start-time="1000" pause-time="5000" emissive="1"></m-video>
+</m-group>
+
+<m-group z="-7.5" x="9" y="2.5">
+  <m-video height="4" src="/assets/timestamp-video.mp4" start-time="-5000" pause-time="5000" emissive="2"></m-video>
+</m-group>

--- a/e2e-tests/src/m-video-test.html
+++ b/e2e-tests/src/m-video-test.html
@@ -3,32 +3,47 @@
 
 <m-label width="5" y="1" rx="-45" z="3" content="This test targets a snapshot of the state at 10000ms of document time. The document time is overridden in e2e tests"></m-label>
 
-<m-group z="-7.5" x="-9" y="8">
+<m-group z="-7.5" x="-9" y="13.5">
   <m-label content="pause-time=0" y="2.75" height="0.75" font-size="40" width="7" alignment="center"></m-label>
   <m-video width="8" src="/assets/timestamp-video.mp4" start-time="0" pause-time="0"></m-video>
 </m-group>
 
-<m-group z="-7.5" x="0" y="8">
+<m-group z="-7.5" x="0" y="13.5">
   <m-label content="enabled=false" y="2.75" height="0.75" font-size="40" width="7" alignment="center"></m-label>
   <m-video width="8" src="/assets/timestamp-video.mp4" enabled="false"></m-video>
 </m-group>
 
-<m-group z="-7.5" x="9" y="8">
+<m-group z="-7.5" x="9" y="13.5">
   <m-label content="pause-time=3000 height=4" y="2.75" height="0.75" font-size="40" width="7" alignment="center"></m-label>
   <m-video height="4" src="/assets/timestamp-video.mp4" pause-time="3000"></m-video>
 </m-group>
 
-<m-group z="-7.5" x="9" y="2.5">
+<m-group z="-7.5" x="9" y="8">
   <m-label content="start-time=-5000 pause-time=5000" y="2.75" height="0.75" font-size="40" width="7" alignment="center"></m-label>
   <m-video height="4" src="/assets/timestamp-video.mp4" start-time="-5000" pause-time="5000"></m-video>
 </m-group>
 
-<m-group z="-7.5" x="-9" y="2.5">
+<m-group z="-7.5" x="-9" y="8">
   <m-label content="pause-time=5000" y="2.75" height="0.75" font-size="40" width="7" alignment="center"></m-label>
   <m-video width="8" src="/assets/timestamp-video.mp4" start-time="0" pause-time="5000"></m-video>
 </m-group>
 
-<m-group z="-7.5" x="0" y="2.5">
+<m-group z="-7.5" x="0" y="8">
   <m-label content="start-time pause-time height+width" y="2.25" height="0.75" font-size="40" width="7" alignment="center"></m-label>
   <m-video width="8" height="3" src="/assets/timestamp-video.mp4" start-time="1000" pause-time="5000"></m-video>
+</m-group>
+
+<m-group z="-7.5" x="9" y="2.5">
+  <m-label content="emissive=1" y="2.75" height="0.75" font-size="40" width="7" alignment="center"></m-label>
+  <m-video height="4" src="/assets/timestamp-video.mp4" start-time="-5000" pause-time="5000" emissive="1"></m-video>
+</m-group>
+
+<m-group z="-7.5" x="-9" y="2.5">
+  <m-label content="no emissive" y="2.75" height="0.75" font-size="40" width="7" alignment="center"></m-label>
+  <m-video width="8" src="/assets/timestamp-video.mp4" start-time="0" pause-time="5000"></m-video>
+</m-group>
+
+<m-group z="-7.5" x="0" y="2.5">
+  <m-label content="emissive=0" y="2.25" height="0.75" font-size="40" width="7" alignment="center"></m-label>
+  <m-video width="8" height="3" src="/assets/timestamp-video.mp4" start-time="1000" pause-time="5000" emissive="0"></m-video>
 </m-group>

--- a/e2e-tests/test/__image_snapshots__/m-video-emissive-test-ts-m-video-emissive-property-of-videos-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-video-emissive-test-ts-m-video-emissive-property-of-videos-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:070966f7e6e24c36e9e20d86a686ddd30507e3bf5f741570668c9dc1f5e30956
+size 45818

--- a/e2e-tests/test/__image_snapshots__/m-video-test-ts-m-video-videos-paused-at-correct-times-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-video-test-ts-m-video-videos-paused-at-correct-times-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f24711ebce6615096df6d72df0ae6de892b7ee586a3c9688877c76e70f6ee9cb
-size 167091
+oid sha256:33040109a3f028e7d0e0d8ef5ab9784956451a0e911009e9e15364608c6de4bb
+size 201180

--- a/e2e-tests/test/__image_snapshots__/m-video-test-ts-m-video-videos-paused-at-correct-times-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-video-test-ts-m-video-videos-paused-at-correct-times-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2221af3cf4621f31f4396bd6f1d3b8b05e3b6a4a91e7b0d1694cf46aa0f61e1e
-size 165409
+oid sha256:f24711ebce6615096df6d72df0ae6de892b7ee586a3c9688877c76e70f6ee9cb
+size 167091

--- a/e2e-tests/test/m-video-emissive.test.ts
+++ b/e2e-tests/test/m-video-emissive.test.ts
@@ -1,0 +1,26 @@
+import { setDocumentTime, takeAndCompareScreenshot } from "./testing-utils";
+
+describe("m-video", () => {
+  test("emissive property of videos", async () => {
+    const page = await __BROWSER_GLOBAL__.newPage();
+
+    await page.setViewport({ width: 1024, height: 1024 });
+
+    await page.goto("http://localhost:7079/m-video-emissive-test.html/reset");
+
+    // Wait for the m-video content to load
+    await page.waitForFunction(
+      () => {
+        const videoMesh = (document.querySelector("m-video") as any).getVideoMesh();
+        return videoMesh.scale.y > 3 && videoMesh.scale.x > 3;
+      },
+      { timeout: 30000, polling: 100 },
+    );
+
+    await setDocumentTime(page, 10000);
+
+    await takeAndCompareScreenshot(page, 0.02);
+
+    await page.close();
+  }, 60000);
+});

--- a/packages/mml-web/src/elements/Video.ts
+++ b/packages/mml-web/src/elements/Video.ts
@@ -28,7 +28,7 @@ const defaultVideoStartTime = 0;
 const defaultVideoPauseTime = null;
 const defaultVideoSrc = null;
 const defaultVideoCastShadows = true;
-const defaultEmissive = 0.5;
+const defaultEmissive = 0;
 
 export class Video extends TransformableElement {
   static tagName = "m-video";
@@ -137,7 +137,9 @@ export class Video extends TransformableElement {
     },
     emissive: (instance, newValue) => {
       instance.props.emissive = parseFloatAttribute(newValue, defaultEmissive);
-      instance.updateMaterialEmissiveIntensity();
+      if (instance.loadedVideoState) {
+        instance.updateMaterialEmissiveIntensity();
+      }
     },
   });
 
@@ -238,11 +240,11 @@ export class Video extends TransformableElement {
       const video = document.createElement("video");
       const material = this.mesh.material;
       const videoTexture = new THREE.VideoTexture(video);
-      videoTexture.colorSpace = THREE.SRGBColorSpace;
-      videoTexture.needsUpdate = true;
-      (material as THREE.MeshStandardMaterial).emissive = new THREE.Color(0xffffff);
-      (material as THREE.MeshStandardMaterial).emissiveMap = videoTexture;
-      (material as THREE.MeshStandardMaterial).emissiveIntensity = this.props.emissive;
+      if (this.props.emissive > 0) {
+        (material as THREE.MeshStandardMaterial).emissive = new THREE.Color(0xffffff);
+        (material as THREE.MeshStandardMaterial).emissiveMap = videoTexture;
+        (material as THREE.MeshStandardMaterial).emissiveIntensity = this.props.emissive;
+      }
       material.map = videoTexture;
       material.needsUpdate = true;
 
@@ -352,10 +354,20 @@ export class Video extends TransformableElement {
   }
 
   private updateMaterialEmissiveIntensity() {
-    if (this.loadedVideoState && this.loadedVideoState.material) {
+    if (this.loadedVideoState) {
       const material = this.loadedVideoState.material as THREE.MeshStandardMaterial;
-      material.emissiveIntensity = this.props.emissive;
-      material.needsUpdate = true;
+      if (this.props.emissive > 0) {
+        const videoTexture = new THREE.VideoTexture(this.loadedVideoState.video);
+        material.emissive = new THREE.Color(0xffffff);
+        material.emissiveMap = videoTexture;
+        material.emissiveIntensity = this.props.emissive;
+        material.needsUpdate = true;
+      } else {
+        material.emissive = new THREE.Color(0x000000);
+        material.emissiveMap = null;
+        material.emissiveIntensity = 1;
+        material.needsUpdate = true;
+      }
     }
   }
 

--- a/packages/mml-web/src/elements/Video.ts
+++ b/packages/mml-web/src/elements/Video.ts
@@ -240,11 +240,6 @@ export class Video extends TransformableElement {
       const video = document.createElement("video");
       const material = this.mesh.material;
       const videoTexture = new THREE.VideoTexture(video);
-      if (this.props.emissive > 0) {
-        (material as THREE.MeshStandardMaterial).emissive = new THREE.Color(0xffffff);
-        (material as THREE.MeshStandardMaterial).emissiveMap = videoTexture;
-        (material as THREE.MeshStandardMaterial).emissiveIntensity = this.props.emissive;
-      }
       material.map = videoTexture;
       material.needsUpdate = true;
 
@@ -259,6 +254,9 @@ export class Video extends TransformableElement {
         material,
         videoTexture,
       };
+      if (this.props.emissive > 0) {
+        this.updateMaterialEmissiveIntensity();
+      }
       this.container.add(audio);
     }
 

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -993,6 +993,13 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="emissive" type="xs:float">
+            <xs:annotation>
+              <xs:documentation>
+                The emissiveness strength of the video (how much perceived light it will emit). Default value is 0.5.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
           <xs:attribute name="loop" type="xs:boolean">
             <xs:annotation>
               <xs:documentation>

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -996,7 +996,7 @@
           <xs:attribute name="emissive" type="xs:float">
             <xs:annotation>
               <xs:documentation>
-                The emissiveness strength of the video (how much perceived light it will emit). Default value is 0.5.
+                The emissiveness strength of the video (how much perceived light it will emit). Default value is 0.
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>


### PR DESCRIPTION
This PR adds the `emissive` attribute for the `<m-video>` tag on `mml-web`. This allows the user to specify the emissive strength of the video (how much perceived light it will emit).

---

**What kind of changes does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)


https://github.com/mml-io/mml/assets/33723163/f58b12d0-e778-4035-ad08-1653c425b45b


