### PR TITLE
m-link (#143)

### DIFF
--- a/e2e-tests/src/assets/a-web-page.html
+++ b/e2e-tests/src/assets/a-web-page.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    This is a static web page
+  </body>
+</html>

--- a/e2e-tests/src/m-link-test.html
+++ b/e2e-tests/src/m-link-test.html
@@ -1,0 +1,7 @@
+<m-plane color="brown" width="15" height="15" rx="-90"></m-plane>
+<m-light type="spotlight" intensity="900" ry="45" rx="65" rz="-45" x="10" y="10" z="10"></m-light>
+<m-group y="2">
+  <m-link href="http://localhost:7079/assets/a-web-page.html">
+    <m-cube id="my-cube" color="green"></m-cube>
+  </m-link>
+</m-group>

--- a/e2e-tests/test/__image_snapshots__/m-link-test-ts-m-link-visible-and-clickable-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-link-test-ts-m-link-visible-and-clickable-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abf511947621e23383c1d1d25405668e84582b92c5d1f16eba5e349721acee6d
+size 41884

--- a/e2e-tests/test/__image_snapshots__/m-link-test-ts-m-link-visible-and-clickable-2-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-link-test-ts-m-link-visible-and-clickable-2-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27293fb606fa7640868c98521ff4812fba1e053012bbfc81419b5401cd473e1a
+size 59730

--- a/e2e-tests/test/__image_snapshots__/m-link-test-ts-m-link-visible-and-clickable-3-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-link-test-ts-m-link-visible-and-clickable-3-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69661e0ee7cc531f6326f8e128fa97c375437abb150c1e89e3bd105f9530bc28
+size 6918

--- a/e2e-tests/test/m-link.test.ts
+++ b/e2e-tests/test/m-link.test.ts
@@ -1,0 +1,36 @@
+import * as puppeteer from "puppeteer";
+
+import { clickElement, takeAndCompareScreenshot } from "./testing-utils";
+
+describe("m-link", () => {
+  test("visible and clickable", async () => {
+    const page = await __BROWSER_GLOBAL__.newPage();
+
+    await page.setViewport({ width: 1024, height: 1024 });
+
+    await page.goto("http://localhost:7079/m-link-test.html/reset");
+
+    await page.waitForSelector("m-link");
+
+    await takeAndCompareScreenshot(page, 0.02);
+
+    await clickElement(page, "#my-cube");
+
+    // Should open a link modal
+    await takeAndCompareScreenshot(page, 0.02);
+
+    const [target] = await Promise.all([
+      new Promise((resolve) => __BROWSER_GLOBAL__.once("targetcreated", resolve)),
+      // Clicking ok should navigate to the link in a new tab
+      page.click("button[data-test-id='confirm-modal-ok-button']"),
+    ]);
+
+    const newPage: puppeteer.Page = await (target as any).page();
+    await newPage.bringToFront();
+
+    // Check contents of new page
+    await takeAndCompareScreenshot(newPage, 0.02);
+
+    await page.close();
+  }, 60000);
+});

--- a/packages/mml-web/src/MMLScene.ts
+++ b/packages/mml-web/src/MMLScene.ts
@@ -34,6 +34,11 @@ export type PromptProps = {
   prefill?: string;
 };
 
+export type LinkProps = {
+  href: string;
+  popup?: boolean;
+};
+
 /**
  * The IMMLScene interface is the public interface for attaching content (E.g. an MML Document) into the underlying
  * (THREE.js) Scene, but it can be implemented by classes other than MMLScene.
@@ -60,9 +65,18 @@ export type IMMLScene = {
 
   getUserPositionAndRotation(): PositionAndRotation;
 
-  prompt: (promptProps: PromptProps, callback: (message: string | null) => void) => void;
+  prompt: (
+    promptProps: PromptProps,
+    abortSignal: AbortSignal,
+    callback: (message: string | null) => void,
+  ) => void;
 
   getLoadingProgressManager?: () => LoadingProgressManager | null;
+  link: (
+    linkProps: LinkProps,
+    abortSignal: AbortSignal,
+    windowCallback: (openedWindow: Window | null) => void,
+  ) => void;
 };
 
 export enum ControlsType {
@@ -266,12 +280,24 @@ export class MMLScene implements IMMLScene {
     this.interactionManager.dispose();
   }
 
-  public prompt(promptProps: PromptProps, callback: (message: string | null) => void) {
+  public prompt(
+    promptProps: PromptProps,
+    abortSignal: AbortSignal,
+    callback: (message: string | null) => void,
+  ) {
     if (!this) {
       console.error("MMLScene not initialized");
       return;
     }
-    this.promptManager.prompt(promptProps, callback);
+    this.promptManager.prompt(promptProps, abortSignal, callback);
+  }
+
+  public link(
+    linkProps: LinkProps,
+    abortSignal: AbortSignal,
+    windowCallback: (openedWindow: Window | null) => void,
+  ) {
+    this.promptManager.link(linkProps, abortSignal, windowCallback);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/mml-web/src/elements/Link.ts
+++ b/packages/mml-web/src/elements/Link.ts
@@ -1,0 +1,69 @@
+import { TransformableElement } from "./TransformableElement";
+import { AttributeHandler } from "../utils/attribute-handling";
+import { OrientedBoundingBox } from "../utils/OrientedBoundingBox";
+
+export class Link extends TransformableElement {
+  static tagName = "m-link";
+
+  private abortController: AbortController | null = null;
+
+  private props = {
+    href: undefined as string | undefined,
+  };
+
+  private static attributeHandler = new AttributeHandler<Link>({
+    href: (instance, newValue) => {
+      instance.props.href = newValue !== null ? newValue : undefined;
+    },
+  });
+
+  static get observedAttributes(): Array<string> {
+    return [...TransformableElement.observedAttributes, ...Link.attributeHandler.getAttributes()];
+  }
+
+  constructor() {
+    super();
+
+    this.addEventListener("click", () => {
+      if (this.props.href) {
+        if (this.abortController) {
+          this.abortController.abort();
+          this.abortController = null;
+        }
+        this.abortController = new AbortController();
+        this.getScene().link(
+          { href: this.props.href, popup: false },
+          this.abortController.signal,
+          () => {
+            this.abortController = null;
+          },
+        );
+      }
+    });
+  }
+
+  public parentTransformed(): void {
+    // no-op
+  }
+
+  public isClickable(): boolean {
+    return false;
+  }
+
+  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+    Link.attributeHandler.handle(this, name, newValue);
+  }
+
+  protected disable(): void {
+    // no-op
+  }
+
+  protected enable(): void {
+    // no-op
+  }
+
+  protected getContentBounds(): OrientedBoundingBox | null {
+    return null;
+  }
+}

--- a/packages/mml-web/src/elements/Prompt.ts
+++ b/packages/mml-web/src/elements/Prompt.ts
@@ -5,6 +5,8 @@ import { OrientedBoundingBox } from "../utils/OrientedBoundingBox";
 export class Prompt extends TransformableElement {
   static tagName = "m-prompt";
 
+  private abortController: AbortController | null = null;
+
   private props = {
     message: undefined as string | undefined,
     placeholder: undefined as string | undefined,
@@ -61,7 +63,12 @@ export class Prompt extends TransformableElement {
   }
 
   private trigger(): void {
-    this.getScene().prompt(this.props, (result) => {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+    this.abortController = new AbortController();
+    this.getScene().prompt(this.props, this.abortController.signal, (result) => {
       if (!this.isConnected) {
         return;
       }

--- a/packages/mml-web/src/elements/register-custom-elements.ts
+++ b/packages/mml-web/src/elements/register-custom-elements.ts
@@ -11,6 +11,7 @@ import { Image } from "./Image";
 import { Interaction } from "./Interaction";
 import { Label } from "./Label";
 import { Light } from "./Light";
+import { Link } from "./Link";
 import { MElement } from "./MElement";
 import { Model } from "./Model";
 import { Plane } from "./Plane";
@@ -35,6 +36,7 @@ export function registerCustomElementsToWindow(targetWindow: Window) {
   targetWindow.customElements.define(Label.tagName, Label);
   targetWindow.customElements.define(Group.tagName, Group);
   targetWindow.customElements.define(Prompt.tagName, Prompt);
+  targetWindow.customElements.define(Link.tagName, Link);
   targetWindow.customElements.define(Sphere.tagName, Sphere);
   targetWindow.customElements.define(Image.tagName, Image);
   targetWindow.customElements.define(Video.tagName, Video);

--- a/packages/mml-web/src/prompt-ui/ConfirmModal.ts
+++ b/packages/mml-web/src/prompt-ui/ConfirmModal.ts
@@ -1,0 +1,48 @@
+import { Modal } from "./Modal";
+
+export class ConfirmModal extends Modal {
+  private confirmContentsElement: HTMLDivElement;
+  private messageElement: HTMLDivElement;
+  private buttonsHolder: HTMLDivElement;
+  private cancelButton: HTMLButtonElement;
+  private okButton: HTMLButtonElement;
+
+  constructor(title: string, message: string, callback: (result: boolean) => void) {
+    super();
+
+    this.titleElement.textContent = title;
+
+    this.confirmContentsElement = document.createElement("div");
+    this.messageElement = document.createElement("div");
+    this.messageElement.textContent = message;
+    this.messageElement.style.marginBottom = "8px";
+    this.confirmContentsElement.appendChild(this.messageElement);
+    this.contentsElement.appendChild(this.confirmContentsElement);
+
+    this.buttonsHolder = document.createElement("div");
+    this.buttonsHolder.style.display = "flex";
+    this.buttonsHolder.style.justifyContent = "space-between";
+    this.buttonsHolder.style.marginTop = "8px";
+
+    this.cancelButton = document.createElement("button");
+    this.cancelButton.setAttribute("data-test-id", "confirm-modal-cancel-button");
+    this.cancelButton.style.cursor = "pointer";
+    this.cancelButton.textContent = "Cancel";
+    this.cancelButton.addEventListener("click", () => {
+      callback(false);
+      this.dispose();
+    });
+    this.buttonsHolder.appendChild(this.cancelButton);
+
+    this.okButton = document.createElement("button");
+    this.okButton.setAttribute("data-test-id", "confirm-modal-ok-button");
+    this.okButton.style.cursor = "pointer";
+    this.okButton.textContent = "OK";
+    this.okButton.addEventListener("click", () => {
+      callback(true);
+      this.dispose();
+    });
+    this.buttonsHolder.appendChild(this.okButton);
+    this.contentsElement.appendChild(this.buttonsHolder);
+  }
+}

--- a/packages/mml-web/src/prompt-ui/PromptManager.ts
+++ b/packages/mml-web/src/prompt-ui/PromptManager.ts
@@ -1,5 +1,7 @@
+import { ConfirmModal } from "./ConfirmModal";
+import { Modal } from "./Modal";
 import { PromptModal } from "./PromptModal";
-import { PromptProps } from "../MMLScene";
+import { LinkProps, PromptProps } from "../MMLScene";
 
 type PromptState = {
   prompt?: PromptModal;
@@ -7,17 +9,20 @@ type PromptState = {
   resolve: (result: string | null) => void;
 };
 
+type LinkState = {
+  href: string;
+  popup: boolean;
+  windowCallback: (openedWindow: Window | null) => void;
+};
+
 export class PromptManager {
   private promptHolderElement: HTMLDivElement;
 
-  private container: HTMLElement;
+  private queue = new Array<PromptState | LinkState>();
+  private currentPrompt: PromptState | LinkState | null = null;
+  private currentModal: Modal | null = null;
 
-  private promptQueue = new Array<PromptState>();
-  private currentPrompt: PromptState | null = null;
-
-  private constructor(container: HTMLElement) {
-    this.container = container;
-
+  private constructor(private container: HTMLElement) {
     const holderElement = document.createElement("div");
     holderElement.setAttribute("data-test-id", "prompt-holder");
     holderElement.style.zIndex = "100";
@@ -26,7 +31,7 @@ export class PromptManager {
     holderElement.style.left = "50%";
     holderElement.style.transform = "translate(-50%, -50%)";
     this.promptHolderElement = holderElement;
-    container.appendChild(this.promptHolderElement);
+    this.container.appendChild(this.promptHolderElement);
   }
 
   static init(container: HTMLElement): PromptManager {
@@ -37,29 +42,120 @@ export class PromptManager {
     this.promptHolderElement.remove();
   }
 
-  private showPrompt(promptState: PromptState) {
+  private showPrompt(promptState: PromptState | LinkState) {
     this.currentPrompt = promptState;
-    const promptModal = new PromptModal(promptState.promptProps, (result: string | null) => {
-      this.currentPrompt = null;
-      promptState.resolve(result);
-      const nextPrompt = this.promptQueue.shift();
-      if (nextPrompt !== undefined) {
-        this.showPrompt(nextPrompt);
-      }
-    });
-    this.promptHolderElement.appendChild(promptModal.element);
-    promptModal.focus();
+    if ("href" in promptState) {
+      const confirmModal = new ConfirmModal(
+        "Confirm Navigation",
+        `Open ${promptState.href}?`,
+        (result: boolean) => {
+          this.currentPrompt = null;
+          this.currentModal = null;
+          if (result) {
+            let features;
+            if (promptState.popup) {
+              const popupWidth = 500;
+              const popupHeight = 500;
+
+              const screenLeft =
+                window.screenLeft !== undefined ? window.screenLeft : window.screenX;
+              const screenTop = window.screenTop !== undefined ? window.screenTop : window.screenY;
+              const windowWidth = window.innerWidth
+                ? window.innerWidth
+                : document.documentElement.clientWidth
+                  ? document.documentElement.clientWidth
+                  : screen.width;
+              const windowHeight = window.innerHeight
+                ? window.innerHeight
+                : document.documentElement.clientHeight
+                  ? document.documentElement.clientHeight
+                  : screen.height;
+
+              const left = (windowWidth - popupWidth) / 2 + screenLeft;
+              const top = (windowHeight - popupHeight) / 2 + screenTop;
+              features = `toolbar=no,menubar=no,width=${popupWidth},height=${popupHeight},left=${left},top=${top}`;
+            }
+
+            const openedWindow = window.open(promptState.href, "_blank", features);
+            promptState.windowCallback(openedWindow);
+          }
+          this.showNextPromptIfAny();
+        },
+      );
+      this.currentModal = confirmModal;
+      this.promptHolderElement.appendChild(confirmModal.element);
+    } else {
+      const promptModal = new PromptModal(promptState.promptProps, (result: string | null) => {
+        this.currentPrompt = null;
+        this.currentModal = null;
+        promptState.resolve(result);
+        this.showNextPromptIfAny();
+      });
+      this.currentModal = promptModal;
+      this.promptHolderElement.appendChild(promptModal.element);
+      promptModal.focus();
+    }
   }
 
-  public prompt(promptProps: PromptProps, callback: (message: string | null) => void) {
+  public prompt(
+    promptProps: PromptProps,
+    abortSignal: AbortSignal,
+    callback: (message: string | null) => void,
+  ) {
+    abortSignal.addEventListener("abort", () => {
+      if (this.currentPrompt === promptState) {
+        // The current prompt is the one we are aborting
+        this.currentPrompt = null;
+        this.currentModal?.dispose();
+        this.showNextPromptIfAny();
+      } else {
+        // Remove the link from the queue
+        this.queue = this.queue.filter((item) => item !== promptState);
+      }
+    });
     const promptState: PromptState = {
       promptProps,
       resolve: callback,
     };
     if (this.currentPrompt !== null) {
-      this.promptQueue.push(promptState);
+      this.queue.push(promptState);
       return;
     }
     this.showPrompt(promptState);
+  }
+
+  public link(
+    linkProps: LinkProps,
+    abortSignal: AbortSignal,
+    windowCallback: (openedWindow: Window | null) => void,
+  ) {
+    abortSignal.addEventListener("abort", () => {
+      if (this.currentPrompt === linkState) {
+        // The current prompt is the one we are aborting
+        this.currentPrompt = null;
+        this.currentModal?.dispose();
+        this.showNextPromptIfAny();
+      } else {
+        // Remove the link from the queue
+        this.queue = this.queue.filter((item) => item !== linkState);
+      }
+    });
+    const linkState: LinkState = {
+      href: linkProps.href,
+      popup: linkProps.popup ?? false,
+      windowCallback,
+    };
+    if (this.currentPrompt !== null) {
+      this.queue.push(linkState);
+      return;
+    }
+    this.showPrompt(linkState);
+  }
+
+  private showNextPromptIfAny() {
+    const nextPrompt = this.queue.shift();
+    if (nextPrompt !== undefined) {
+      this.showPrompt(nextPrompt);
+    }
   }
 }

--- a/packages/mml-web/src/prompt-ui/PromptModal.ts
+++ b/packages/mml-web/src/prompt-ui/PromptModal.ts
@@ -91,6 +91,7 @@ export class PromptModal extends Modal {
   }
 
   dispose() {
+    this.eventHandlerCollection.clear();
     super.dispose();
   }
 

--- a/packages/mml-web/src/utils/frame/CreateWrappedScene.ts
+++ b/packages/mml-web/src/utils/frame/CreateWrappedScene.ts
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { Interaction, MElement } from "../../elements";
 import { ChatProbe } from "../../elements/ChatProbe";
 import { LoadingProgressManager } from "../../loading/LoadingProgressManager";
-import { IMMLScene, PromptProps } from "../../MMLScene";
+import { IMMLScene, LinkProps, PromptProps } from "../../MMLScene";
 
 export function createWrappedScene(
   scene: IMMLScene,
@@ -68,8 +68,19 @@ export function createWrappedScene(
     getCamera(): THREE.Camera {
       return scene.getCamera();
     },
-    prompt(promptProps: PromptProps, callback: (result: string | null) => void) {
-      scene.prompt(promptProps, callback);
+    prompt(
+      promptProps: PromptProps,
+      abortSignal: AbortSignal,
+      callback: (result: string | null) => void,
+    ) {
+      scene.prompt(promptProps, abortSignal, callback);
+    },
+    link(
+      linkProps: LinkProps,
+      abortSignal: AbortSignal,
+      windowCallback: (openedWindow: Window) => void,
+    ) {
+      scene.link(linkProps, abortSignal, windowCallback);
     },
     getRootContainer: () => {
       return container;

--- a/packages/mml-web/test/link.test.ts
+++ b/packages/mml-web/test/link.test.ts
@@ -1,0 +1,28 @@
+import { testElementSchemaMatchesObservedAttributes } from "./schema-utils";
+import { Link } from "../src/elements/Link";
+import { registerCustomElementsToWindow } from "../src/elements/register-custom-elements";
+import { RemoteDocument } from "../src/elements/RemoteDocument";
+import { FullScreenMMLScene } from "../src/FullScreenMMLScene";
+
+beforeAll(() => {
+  registerCustomElementsToWindow(window);
+});
+
+describe("m-link", () => {
+  test("test attachment to scene", () => {
+    const scene = new FullScreenMMLScene();
+    const sceneAttachment = document.createElement("m-remote-document") as RemoteDocument;
+    sceneAttachment.init(scene, "ws://localhost:8080");
+    document.body.append(sceneAttachment);
+
+    const element = document.createElement("m-link") as Link;
+    sceneAttachment.append(element);
+
+    expect(scene.getThreeScene().children[0].children[0].children[0]).toBe(element.getContainer());
+  });
+
+  test("observes the schema-specified attributes", () => {
+    const schema = testElementSchemaMatchesObservedAttributes("m-link", Link);
+    expect(schema.name).toEqual(Link.tagName);
+  });
+});

--- a/packages/schema-validator/test/elements/m-link.test.ts
+++ b/packages/schema-validator/test/elements/m-link.test.ts
@@ -1,0 +1,21 @@
+import { validateMMLDocument } from "../../src";
+
+test("<m-link>", () => {
+  const validationErrors = validateMMLDocument(`
+<m-link
+  id="my-link"
+  class="some-link-class"
+  x="1.1" 
+  y="2.2" 
+  z="3.3" 
+  rx="45.45" 
+  ry="90.90" 
+  rz="135.135" 
+  sx="1.1" 
+  sy="2.2" 
+  sz="3.3"
+  href="https://example.com/some-link"
+></m-link>
+`);
+  expect(validationErrors).toBeNull();
+});

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -359,6 +359,7 @@
       <xs:element ref="m-image"/>
       <xs:element ref="m-video"/>
       <xs:element ref="m-prompt"/>
+      <xs:element ref="m-link"/>
       <xs:element ref="m-position-probe"/>
       <xs:element ref="m-chat-probe"/>
       <xs:element ref="m-interaction"/>
@@ -1202,6 +1203,34 @@
               <xs:appinfo>prompt|MMLPromptEvent</xs:appinfo>
               <xs:documentation>
                 A script expression to be executed when a user submits their input.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="m-link">
+    <xs:annotation>
+      <xs:documentation>
+        The `m-link` element is used to open a web address when the element is clicked in a 3D scene.
+
+        The web address is opened in a new tab or window depending on the client implementation.
+
+        The `m-link` element has no visual representation in the scene; clicking children of element activates the link.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="MMLContent">
+          <xs:attributeGroup ref="debuggable"/>
+          <xs:attributeGroup ref="transformable"/>
+          <xs:attributeGroup ref="coreattrs"/>
+          <xs:attribute name="href" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                The web address to open when the link is clicked.
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>


### PR DESCRIPTION
Resolves #143.

This PR adds the `m-link` element that allows opening a web address by clicking 3d elements that are children of the `m-link`.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
