### PR TITLE
m-image emissive attribute

### DIFF
--- a/e2e-tests/src/m-image-emissive-test.html
+++ b/e2e-tests/src/m-image-emissive-test.html
@@ -1,0 +1,3 @@
+<m-image src="/assets/test-image.png" y="4" x="-3" width="5" emissive="1"></m-image>
+<m-image src="/assets/test-image.png" x="3.8" y="3.5" z="-4" width="6" emissive="0"></m-image>
+<m-image src="/assets/transparency-test-image.png" y="4" x="3" width="5" emissive="3"></m-image>

--- a/e2e-tests/test/__image_snapshots__/m-image-emissive-test-ts-m-image-emissive-image-emissive-parameters-1-snap.png
+++ b/e2e-tests/test/__image_snapshots__/m-image-emissive-test-ts-m-image-emissive-image-emissive-parameters-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f52a3f1aa5d690793b0ab35768e7b181dfc382696d5cca24ecba97ce29c2384b
+size 25918

--- a/e2e-tests/test/m-image-emissive.test.ts
+++ b/e2e-tests/test/m-image-emissive.test.ts
@@ -1,0 +1,25 @@
+import { takeAndCompareScreenshot } from "./testing-utils";
+
+describe("m-image-emissive", () => {
+  test("image emissive parameters", async () => {
+    const page = await __BROWSER_GLOBAL__.newPage();
+
+    await page.setViewport({ width: 1024, height: 1024 });
+
+    await page.goto("http://localhost:7079/m-image-emissive-test.html/reset");
+
+    // Wait for the m-image content to load
+    await page.waitForFunction(
+      () => {
+        return Array.from(document.querySelectorAll("m-image") as any).every(
+          (img: any) => img.getImageMesh().scale.y > 3,
+        );
+      },
+      { timeout: 30000, polling: 100 },
+    );
+
+    await takeAndCompareScreenshot(page, 0.02);
+
+    await page.close();
+  }, 60000);
+});

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -945,6 +945,13 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="emissive" type="xs:float">
+            <xs:annotation>
+              <xs:documentation>
+                The emissiveness strength of the image (how much perceived light it will emit). Default value is 0.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
           <xs:attribute name="opacity" type="xs:float">
             <xs:annotation>
               <xs:documentation>


### PR DESCRIPTION
This PR adds the `emissive` attribute to the `<m-image>` tag on `mml-web`. This allows the user to specify the emissive strength of the image's generated texture (how much perceived light it will emit).

---

**What kind of changes does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)

![Screenshot 2024-07-10 at 16 51 06](https://github.com/mml-io/mml/assets/33723163/01969681-2044-4804-8056-9c76bd3f23e7)
