### PR TITLE
Add m-link target attribute

### DIFF
--- a/packages/mml-web/src/MMLScene.ts
+++ b/packages/mml-web/src/MMLScene.ts
@@ -36,6 +36,7 @@ export type PromptProps = {
 
 export type LinkProps = {
   href: string;
+  target?: string;
   popup?: boolean;
 };
 

--- a/packages/mml-web/src/prompt-ui/PromptManager.ts
+++ b/packages/mml-web/src/prompt-ui/PromptManager.ts
@@ -11,6 +11,7 @@ type PromptState = {
 
 type LinkState = {
   href: string;
+  target?: string;
   popup: boolean;
   windowCallback: (openedWindow: Window | null) => void;
 };
@@ -76,7 +77,11 @@ export class PromptManager {
               features = `toolbar=no,menubar=no,width=${popupWidth},height=${popupHeight},left=${left},top=${top}`;
             }
 
-            const openedWindow = window.open(promptState.href, "_blank", features);
+            const openedWindow = window.open(
+              promptState.href,
+              promptState.target ?? "_blank",
+              features,
+            );
             promptState.windowCallback(openedWindow);
           }
           this.showNextPromptIfAny();
@@ -142,6 +147,7 @@ export class PromptManager {
     });
     const linkState: LinkState = {
       href: linkProps.href,
+      target: linkProps.target,
       popup: linkProps.popup ?? false,
       windowCallback,
     };

--- a/packages/mml-web/test/link.test.ts
+++ b/packages/mml-web/test/link.test.ts
@@ -25,4 +25,16 @@ describe("m-link", () => {
     const schema = testElementSchemaMatchesObservedAttributes("m-link", Link);
     expect(schema.name).toEqual(Link.tagName);
   });
+
+  test("isAcceptableHref", () => {
+    expect(Link.isAcceptableHref("http://example.com")).toBe(true);
+    expect(Link.isAcceptableHref("https://example.com")).toBe(true);
+    expect(Link.isAcceptableHref("https://example.com/foo")).toBe(true);
+    expect(Link.isAcceptableHref("/foo")).toBe(true);
+    expect(Link.isAcceptableHref("/")).toBe(true);
+
+    expect(Link.isAcceptableHref("ftp://example.com")).toBe(false);
+    expect(Link.isAcceptableHref("javascript:alert('foo')")).toBe(false);
+    expect(Link.isAcceptableHref("mailto:test@example.com")).toBe(false);
+  });
 });

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -1255,6 +1255,13 @@
               </xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="target" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Where the address should be opened. "_self" opens in the current context / tab / window (if the content is in a context in which that is valid). "_blank" opens in a new tab / window. Default value is "_blank".
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>


### PR DESCRIPTION
This PR adds a `target` attribute to the `m-link` element.

This also necessitated restricting the `href` values that can be used because with the inclusion of `_self` as a `target` URLs such as `javascript:alert('foo');` would run in the current window and be trivially exploitable.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] Yes

If yes, please describe its impact and migration path for existing applications:

Minor: Using a `href` such as `javascript:alert('foo');` would previously have opened a new tab and run that script. Now the link will not open.

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
