### PR TITLE
Fix m-video volume setting

### DIFF
--- a/packages/mml-web-playcanvas/src/elements/PlayCanvasVideo.ts
+++ b/packages/mml-web-playcanvas/src/elements/PlayCanvasVideo.ts
@@ -30,6 +30,7 @@ export class PlayCanvasVideo extends VideoGraphics<PlayCanvasGraphicsAdapter> {
     videoLoadEventCollection: EventHandlerCollection;
     videoTexture: playcanvas.Texture | null;
     audio: {
+      gainNode: GainNode;
       audioNode: AudioNode;
       panner: PannerNode;
     } | null;
@@ -153,7 +154,9 @@ export class PlayCanvasVideo extends VideoGraphics<PlayCanvasGraphicsAdapter> {
   }
 
   public setVolume(): void {
-    this.updateVideo();
+    if (this.loadedVideoState?.audio) {
+      this.loadedVideoState.audio.gainNode.gain.value = this.video.props.volume;
+    }
   }
 
   public setEmissive(): void {
@@ -257,6 +260,7 @@ export class PlayCanvasVideo extends VideoGraphics<PlayCanvasGraphicsAdapter> {
           });
 
           const gainNode = audioContext.createGain();
+          gainNode.gain.value = this.video.props.volume;
           const stereoPanner = new StereoPannerNode(audioContext, { pan: 0 });
           const audioNode = audioContext.createMediaElementSource(video);
           audioNode
@@ -264,7 +268,8 @@ export class PlayCanvasVideo extends VideoGraphics<PlayCanvasGraphicsAdapter> {
             .connect(stereoPanner)
             .connect(panner)
             .connect(audioContext.destination);
-          this.loadedVideoState.audio = { audioNode, panner };
+
+          this.loadedVideoState.audio = { gainNode, audioNode, panner };
         });
       }
     }

--- a/packages/mml-web-threejs/src/elements/ThreeJSVideo.ts
+++ b/packages/mml-web-threejs/src/elements/ThreeJSVideo.ts
@@ -122,7 +122,9 @@ export class ThreeJSVideo extends VideoGraphics<ThreeJSGraphicsAdapter> {
   }
 
   public setVolume(): void {
-    this.updateVideo();
+    if (this.loadedVideoState) {
+      this.loadedVideoState.audio.setVolume(this.video.props.volume);
+    }
   }
 
   public setEmissive(): void {


### PR DESCRIPTION
Fix an issue where the `volume` attribute was not applied to ThreeJS or PlayCanvas videos

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
