### PR TITLE
Fix v0.2 websocket batching

### DIFF
--- a/packages/networked-dom-document/src/NetworkedDOMV02Connection.ts
+++ b/packages/networked-dom-document/src/NetworkedDOMV02Connection.ts
@@ -83,7 +83,7 @@ export class NetworkedDOMV02Connection {
   }
 
   public sendMessage(message: NetworkedDOMV02ServerMessage) {
-    this.webSocket.send(encodeServerMessage(message).getBuffer());
+    this.sendEncodedBytes(encodeServerMessage(message).getBuffer());
   }
 
   public sendMessages(messages: Array<NetworkedDOMV02ServerMessage>) {
@@ -92,7 +92,7 @@ export class NetworkedDOMV02Connection {
       encodeServerMessage(message, bufferWriter);
     }
     const bytes = bufferWriter.getBuffer();
-    this.webSocket.send(bytes);
+    this.sendEncodedBytes(bytes);
   }
 
   public sendEncodedBytes(bytes: Uint8Array) {


### PR DESCRIPTION
Fixes an issue where a `networked-dom-v0.2` websocket connection could be in batch mode (grouping multiple diffs together) and then a message that should be in the middle of the batch would be sent ahead of it because the sending calls did not respect batching.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
