### PR TITLE
Change hidden iframe style to prevent throttling

### DIFF
--- a/packages/networked-dom-web-runner/src/RunnerIframe.ts
+++ b/packages/networked-dom-web-runner/src/RunnerIframe.ts
@@ -26,7 +26,8 @@ export class RunnerIframe {
     this.iframe.style.width = "0";
     this.iframe.style.height = "0";
     this.iframe.style.border = "none";
-    this.iframe.style.visibility = "hidden";
+    this.iframe.style.opacity = "0";
+    this.iframe.style.pointerEvents = "none";
 
     const paramsMinusCode: Partial<ObservableDOMParameters> = {
       ...this.observableDOMParameters,


### PR DESCRIPTION
This PR changes the styling of the `RunnerIframe` to prevent throttling / disabling of the iframe's timing (`document.timeline.currentTime` does not progress) in some browsers (notably Chrome).

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
