### PR TITLE
fixes the commands to start ci:e2e-tests to prevent it from failing to start

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -10,9 +10,9 @@
     "lint": "eslint \"./**/*.{js,jsx,ts,tsx}\" --max-warnings 0",
     "lint-fix": "eslint \"./**/*.{js,jsx,ts,tsx}\" --fix",
     "serve": "node --enable-source-maps ./build/index.js",
-    "ci:e2e-tests": "npm run wait-for-ports && HEADLESS=true jest --runInBand",
+    "ci:e2e-tests": "concurrently --max-processes 2 --success command-1 --kill-others \"NX_CACHE=false lerna run serve --scope e2e-tests\" \"npm run wait-for-ports && HEADLESS=true jest --runInBand\"",
     "e2e-tests": "npm run wait-for-ports && HEADLESS=false jest --runInBand",
-    "wait-for-ports": "npx wait-on http://127.0.0.1:7079 -t 60000"
+    "wait-for-ports": "npx wait-on http://localhost:7079/mml-logo.html -t 90000 --httpTimeout 5000 --interval 500"
   },
   "dependencies": {
     "@mml-io/networked-dom-server": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "link-all": "lerna exec \"npm link\" --no-private && npm run print-links",
     "print-links": "echo \"Run this command in the package you would like to link this repo's packages to:\n\"; echo \"npm link\" $(lerna ls --loglevel=error)",
     "version": "lerna version --no-push --force-publish",
-    "ci:e2e-tests": "concurrently --success command-1 --kill-others \"lerna run serve --scope e2e-tests\" \"lerna run --stream ci:e2e-tests\"",
+    "ci:e2e-tests": "lerna run --stream ci:e2e-tests",
     "e2e-tests": "lerna run --stream e2e-tests"
   },
   "workspaces": [


### PR DESCRIPTION
This PR aims to eliminate the inconsistencies we have been facing when starting the headless e2e tests in CI (GitHub workflow) by changing the script that runs the tests.

We frequently had the tests fail to start with an `e2e-tests exited with code 135` error, and the updated commands have shown to work consistently.

`wait-on` parameters explained:
- http://localhost:7079/mml-logo.html (last document to be served by the `serve` script)
-  -t 90000 (wait-on will try for a maximum of 90 seconds)
-  --httpTimeout 5000 (the HTTP request will timeout in 5 seconds on each pooling attempt)
- --interval 500 (wait-on will check the resource twice per second)

---

**What kind of changes does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
