### PR TITLE
Handle changeVisibleTo in end user client with no-op

### DIFF
--- a/packages/networked-dom-web/src/NetworkedDOMWebsocketV02Adapter.ts
+++ b/packages/networked-dom-web/src/NetworkedDOMWebsocketV02Adapter.ts
@@ -144,6 +144,9 @@ export class NetworkedDOMWebsocketV02Adapter implements NetworkedDOMWebsocketAda
       case "changeHiddenFrom":
         this.handleChangeHiddenFrom(message);
         break;
+      case "changeVisibleTo":
+        // no-op for end user clients
+        break;
       case "childrenRemoved":
         this.handleChildrenRemoved(message);
         break;


### PR DESCRIPTION
The `changeVisibleTo` message type is received by end user clients even though they only represent a single user and therefore do not need to change the visibility of any elements. This PR just makes the handling of this as a no-op explicit and avoids a warning log.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
