### PR TITLE
Fix 'Not currently loading - cannot finish' error with m-model (#156)

### DIFF
--- a/packages/mml-web-playcanvas/src/elements/PlayCanvasModel.ts
+++ b/packages/mml-web-playcanvas/src/elements/PlayCanvasModel.ts
@@ -316,6 +316,7 @@ export class PlayCanvasModel extends ModelGraphics<PlayCanvasGraphicsAdapter> {
       this.updateDebugVisualisation();
     }
     if (!src) {
+      this.latestSrcModelPromise = null;
       this.srcLoadingInstanceManager.abortIfLoading();
       this.socketChildrenByBone.forEach((children) => {
         children.forEach((child) => {
@@ -328,10 +329,13 @@ export class PlayCanvasModel extends ModelGraphics<PlayCanvasGraphicsAdapter> {
     }
 
     const contentSrc = this.model.contentSrcToContentAddress(src);
+    this.srcLoadingInstanceManager.start(this.model.getLoadingProgressManager(), contentSrc);
     const srcModelPromise = this.asyncLoadSourceAsset(contentSrc, (loaded, total) => {
+      if (this.latestSrcModelPromise !== srcModelPromise) {
+        return;
+      }
       this.srcLoadingInstanceManager.setProgress(loaded / total);
     });
-    this.srcLoadingInstanceManager.start(this.model.getLoadingProgressManager(), contentSrc);
     this.latestSrcModelPromise = srcModelPromise;
     srcModelPromise
       .then((asset) => {
@@ -510,6 +514,8 @@ export class PlayCanvasModel extends ModelGraphics<PlayCanvasGraphicsAdapter> {
       this.loadedState = null;
     }
     this.clearDebugVisualisation();
+    this.latestSrcModelPromise = null;
+    this.latestAnimPromise = null;
     this.animLoadingInstanceManager.dispose();
     this.srcLoadingInstanceManager.dispose();
   }

--- a/packages/mml-web-threejs/src/elements/ThreeJSModel.ts
+++ b/packages/mml-web-threejs/src/elements/ThreeJSModel.ts
@@ -139,10 +139,13 @@ export class ThreeJSModel extends ModelGraphics<ThreeJSGraphicsAdapter> {
     }
 
     const animSrc = this.model.contentSrcToContentAddress(anim);
+    this.animLoadingInstanceManager.start(this.model.getLoadingProgressManager(), animSrc);
     const animPromise = this.asyncLoadSourceAsset(animSrc, (loaded, total) => {
+      if (this.latestAnimPromise !== animPromise) {
+        return;
+      }
       this.animLoadingInstanceManager.setProgress(loaded / total);
     });
-    this.animLoadingInstanceManager.start(this.model.getLoadingProgressManager(), animSrc);
     this.latestAnimPromise = animPromise;
     animPromise
       .then((result) => {
@@ -200,6 +203,7 @@ export class ThreeJSModel extends ModelGraphics<ThreeJSGraphicsAdapter> {
       this.updateDebugVisualisation();
     }
     if (!src) {
+      this.latestSrcModelPromise = null;
       this.srcLoadingInstanceManager.abortIfLoading();
       this.socketChildrenByBone.forEach((children) => {
         children.forEach((child) => {
@@ -212,10 +216,13 @@ export class ThreeJSModel extends ModelGraphics<ThreeJSGraphicsAdapter> {
     }
 
     const contentSrc = this.model.contentSrcToContentAddress(src);
+    this.srcLoadingInstanceManager.start(this.model.getLoadingProgressManager(), contentSrc);
     const srcModelPromise = this.asyncLoadSourceAsset(contentSrc, (loaded, total) => {
+      if (this.latestSrcModelPromise !== srcModelPromise) {
+        return;
+      }
       this.srcLoadingInstanceManager.setProgress(loaded / total);
     });
-    this.srcLoadingInstanceManager.start(this.model.getLoadingProgressManager(), contentSrc);
     this.latestSrcModelPromise = srcModelPromise;
     srcModelPromise
       .then((result) => {
@@ -274,6 +281,7 @@ export class ThreeJSModel extends ModelGraphics<ThreeJSGraphicsAdapter> {
         if (this.animState) {
           this.playAnimation(this.animState.currentAnimationClip);
         }
+        console.log("Loaded model", this.loadedState);
         this.srcLoadingInstanceManager.finish();
 
         this.updateDebugVisualisation();
@@ -502,6 +510,8 @@ export class ThreeJSModel extends ModelGraphics<ThreeJSGraphicsAdapter> {
       this.loadedState = null;
     }
     this.clearDebugVisualisation();
+    this.latestSrcModelPromise = null;
+    this.latestAnimPromise = null;
     this.animLoadingInstanceManager.dispose();
     this.srcLoadingInstanceManager.dispose();
   }


### PR DESCRIPTION
Fix #156.

Fixes handling of case where an `m-model` is disposed of and the load progress continues and finishes. This PR checks if the load event is for the currently-active resource.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [x] The title references the corresponding issue # (if relevant)
