### PR TITLE
Fix m-frame initial load

### DIFF
--- a/packages/mml-web/src/elements/Frame.ts
+++ b/packages/mml-web/src/elements/Frame.ts
@@ -28,6 +28,7 @@ export type MFrameProps = {
 export class Frame<G extends GraphicsAdapter = GraphicsAdapter> extends TransformableElement<G> {
   static tagName = "m-frame";
   private frameGraphics: FrameGraphics<G> | null;
+  private hasInitialized = false;
 
   private static attributeHandler = new AttributeHandler<Frame<GraphicsAdapter>>({
     src: (instance, newValue) => {
@@ -131,6 +132,9 @@ export class Frame<G extends GraphicsAdapter = GraphicsAdapter> extends Transfor
   };
 
   private shouldBeLoaded() {
+    if (!this.hasInitialized) {
+      return false;
+    }
     if (!this.isConnected) {
       return false;
     }
@@ -286,9 +290,6 @@ export class Frame<G extends GraphicsAdapter = GraphicsAdapter> extends Transfor
     }
     const graphicsAdapter = this.getScene().getGraphicsAdapter();
 
-    this.startEmitting();
-    this.syncLoadState();
-
     this.frameGraphics = graphicsAdapter
       .getGraphicsAdapterFactory()
       .MMLFrameGraphicsInterface(this);
@@ -299,6 +300,11 @@ export class Frame<G extends GraphicsAdapter = GraphicsAdapter> extends Transfor
         this.attributeChangedCallback(name, null, value);
       }
     }
+
+    // Don't allow the frame to be loaded until after all attributes have been observed
+    this.hasInitialized = true;
+    this.startEmitting();
+    this.syncLoadState();
 
     this.applyBounds();
   }


### PR DESCRIPTION
This PR fixes the initial loading behaviour of `m-frame`s.

Currently if an `m-frame` is out of bounds due to a `load-range` attribute it will start loading when the element is added with a `src` because the `load-range` attribute has not yet been observed.

This PR adds an `hasInitialized` property to allow ignoring the attributes behaviour until after all attributes are observed.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
