### PR TITLE
Close hanging websockets on timeout

### DIFF
--- a/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
+++ b/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
@@ -92,10 +92,11 @@ export class NetworkedDOMWebsocket {
 
   private createWebsocketWithTimeout(timeout: number): Promise<WebSocket> {
     return new Promise((resolve, reject) => {
+      const websocket = this.websocketFactory(this.url);
       const timeoutId = setTimeout(() => {
         reject(new Error("websocket connection timed out"));
+        websocket.close();
       }, timeout);
-      const websocket = this.websocketFactory(this.url);
       websocket.binaryType = "arraybuffer";
       websocket.addEventListener("open", () => {
         clearTimeout(timeoutId);

--- a/packages/networked-dom-web/src/NetworkedDOMWebsocketV02Adapter.ts
+++ b/packages/networked-dom-web/src/NetworkedDOMWebsocketV02Adapter.ts
@@ -59,7 +59,8 @@ export class NetworkedDOMWebsocketV02Adapter implements NetworkedDOMWebsocketAda
   public handleEvent(element: HTMLElement, event: CustomEvent<{ element: HTMLElement }>) {
     const nodeId = this.elementToId.get(element);
     if (nodeId === undefined || nodeId === null) {
-      throw new Error("Element not found");
+      console.error("Element not found for event", { nodeId, element, event });
+      return;
     }
 
     const detailWithoutElement: Partial<typeof event.detail> = {


### PR DESCRIPTION
This PR fixes an issue where websockets that were opened to connect to a remote document, but were abandoned because of a timeout would stay open, but unused.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
