### PR TITLE
Fix NetworkedDOM leaking connection ids

### DIFF
--- a/packages/networked-dom-document/src/NetworkedDOM.ts
+++ b/packages/networked-dom-document/src/NetworkedDOM.ts
@@ -520,6 +520,7 @@ export class NetworkedDOM {
       networkedDOMConnection.externalConnectionIds.delete(removingExternalId);
       networkedDOMConnection.externalIdToInternalId.delete(removingExternalId);
       networkedDOMConnection.internalIdToExternalId.delete(removingInternalId);
+      this.connectionIdToNetworkedDOMConnection.delete(removingInternalId);
     }
 
     // Remove the nodes that are only visible to this connection because of


### PR DESCRIPTION
Fix NetworkedDOM leaking connection ids on `disconnectUsers`

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
