### PR TITLE
Viewer Loading Config and Updatable Params

### DIFF
--- a/packages/mml-viewer/src/GraphicsMode.ts
+++ b/packages/mml-viewer/src/GraphicsMode.ts
@@ -1,7 +1,9 @@
 import { FormIteration } from "./FormIteration";
+import { MMLSourceDefinition } from "./MMLSourceDefinition";
 
 export type GraphicsMode = {
   type: string;
   dispose: () => void;
   update: (formIteration: FormIteration) => void;
+  updateSource(source: MMLSourceDefinition): void;
 };

--- a/packages/mml-viewer/src/PlayCanvasMode.ts
+++ b/packages/mml-viewer/src/PlayCanvasMode.ts
@@ -1,6 +1,7 @@
 import { FormIteration } from "./FormIteration";
 import { GraphicsMode } from "./GraphicsMode";
 import { MMLSourceDefinition } from "./MMLSourceDefinition";
+import { PlayCanvasModeOptions } from "./PlayCanvasModeInternal";
 
 export class PlayCanvasMode implements GraphicsMode {
   private disposed = false;
@@ -13,7 +14,7 @@ export class PlayCanvasMode implements GraphicsMode {
     private targetForWrappers: HTMLElement,
     private mmlSource: MMLSourceDefinition,
     private formIteration: FormIteration,
-    private showDebugLoading: boolean,
+    private options: PlayCanvasModeOptions,
   ) {
     this.init();
   }
@@ -33,7 +34,7 @@ export class PlayCanvasMode implements GraphicsMode {
         this.targetForWrappers,
         this.mmlSource,
         this.formIteration,
-        this.showDebugLoading,
+        this.options,
       );
     })();
     if (this.disposed) {

--- a/packages/mml-viewer/src/PlayCanvasMode.ts
+++ b/packages/mml-viewer/src/PlayCanvasMode.ts
@@ -18,6 +18,13 @@ export class PlayCanvasMode implements GraphicsMode {
     this.init();
   }
 
+  public updateSource(source: MMLSourceDefinition): void {
+    this.mmlSource = source;
+    if (this.internalMode) {
+      this.internalMode.updateSource(source);
+    }
+  }
+
   private async init() {
     this.internalMode = await (async () => {
       const { PlayCanvasModeInternal } = await import("./PlayCanvasModeInternal");

--- a/packages/mml-viewer/src/PlayCanvasModeInternal.ts
+++ b/packages/mml-viewer/src/PlayCanvasModeInternal.ts
@@ -59,6 +59,27 @@ export class PlayCanvasModeInternal {
     this.init();
   }
 
+  public updateSource(source: MMLSourceDefinition): void {
+    this.mmlSourceDefinition = source;
+    if (this.loadedState) {
+      const existingSource = this.loadedState.mmlNetworkSource;
+      existingSource.dispose();
+      this.loadedState.mmlNetworkSource = MMLNetworkSource.create({
+        mmlScene: this.loadedState.fullScreenMMLScene,
+        statusUpdated: (status: NetworkedDOMWebsocketStatus) => {
+          this.loadedState?.statusUI.setStatus(NetworkedDOMWebsocketStatusToString(status));
+        },
+        url: source.url,
+        windowTarget: this.windowTarget,
+        targetForWrappers: this.targetForWrappers,
+      });
+      setDebugGlobals({
+        mmlScene: this.loadedState.fullScreenMMLScene,
+        remoteDocumentWrapper: this.loadedState.mmlNetworkSource.remoteDocumentWrapper,
+      });
+    }
+  }
+
   private async init() {
     const fullScreenMMLScene = new FullScreenMMLScene<StandalonePlayCanvasAdapter>(
       this.showDebugLoading,

--- a/packages/mml-viewer/src/StandaloneViewer.ts
+++ b/packages/mml-viewer/src/StandaloneViewer.ts
@@ -4,10 +4,12 @@ import { FormIteration } from "./FormIteration";
 import { GraphicsMode } from "./GraphicsMode";
 import { MMLSourceDefinition } from "./MMLSourceDefinition";
 import { PlayCanvasMode } from "./PlayCanvasMode";
+import { PlayCanvasModeOptions } from "./PlayCanvasModeInternal";
 import { QueryParamState } from "./QueryParamState";
 import { TagsMode } from "./TagsMode";
 import { ThreeJSMode } from "./ThreeJSMode";
-import { rendererField, urlField } from "./ui/fields";
+import { ThreeJSModeOptions } from "./ThreeJSModeInternal";
+import { hideUntilLoadedField, loadingStyleField, rendererField, urlField } from "./ui/fields";
 import { ViewerUI } from "./ui/ViewerUI";
 
 export class StandaloneViewer {
@@ -52,6 +54,7 @@ export class StandaloneViewer {
 
     const url = formIteration.getFieldValue(urlField);
     const renderer = formIteration.getFieldValue(rendererField);
+    const loadingStyle = formIteration.getFieldValue(loadingStyleField);
     const noUI = parseBoolAttribute(queryParamState.read("noUI"), false);
     if (noUI) {
       this.viewerUI.hide();
@@ -86,6 +89,17 @@ export class StandaloneViewer {
     }
     this.viewerUI.hideAddressMenu();
 
+    const hideUntilLoaded = parseBoolAttribute(
+      formIteration.getFieldValue(hideUntilLoadedField),
+      false,
+    );
+
+    const options: ThreeJSModeOptions | PlayCanvasModeOptions = {
+      loadingStyle: loadingStyle as "bar" | "spinner",
+      hideUntilLoaded,
+      showDebugLoading: !noUI,
+    };
+
     if (!this.graphicsMode) {
       if (renderer === "playcanvas") {
         this.graphicsMode = new PlayCanvasMode(
@@ -93,7 +107,7 @@ export class StandaloneViewer {
           this.targetForWrappers,
           source,
           formIteration,
-          !noUI,
+          options,
         );
       } else if (renderer === "threejs") {
         this.graphicsMode = new ThreeJSMode(
@@ -101,7 +115,7 @@ export class StandaloneViewer {
           this.targetForWrappers,
           source,
           formIteration,
-          !noUI,
+          options,
         );
       } else if (renderer === "tags") {
         this.graphicsMode = new TagsMode(

--- a/packages/mml-viewer/src/TagsMode.ts
+++ b/packages/mml-viewer/src/TagsMode.ts
@@ -34,6 +34,27 @@ export class TagsMode implements GraphicsMode {
 
   public readonly type = "tags";
 
+  public updateSource(source: MMLSourceDefinition): void {
+    this.mmlSourceDefinition = source;
+    if (this.loadedState) {
+      const existingSource = this.loadedState.mmlNetworkSource;
+      existingSource.dispose();
+      this.loadedState.mmlNetworkSource = MMLNetworkSource.create({
+        mmlScene: this.loadedState.fullScreenMMLScene,
+        statusUpdated: (status: NetworkedDOMWebsocketStatus) => {
+          this.loadedState?.statusUI.setStatus(NetworkedDOMWebsocketStatusToString(status));
+        },
+        url: source.url,
+        windowTarget: this.windowTarget,
+        targetForWrappers: this.targetForWrappers,
+      });
+      setDebugGlobals({
+        mmlScene: this.loadedState.fullScreenMMLScene,
+        remoteDocumentWrapper: this.loadedState.mmlNetworkSource.remoteDocumentWrapper,
+      });
+    }
+  }
+
   private async init() {
     const fullScreenMMLScene = new FullScreenMMLScene<StandaloneTagDebugAdapter>(
       this.showDebugLoading,

--- a/packages/mml-viewer/src/TagsMode.ts
+++ b/packages/mml-viewer/src/TagsMode.ts
@@ -56,9 +56,9 @@ export class TagsMode implements GraphicsMode {
   }
 
   private async init() {
-    const fullScreenMMLScene = new FullScreenMMLScene<StandaloneTagDebugAdapter>(
-      this.showDebugLoading,
-    );
+    const fullScreenMMLScene = new FullScreenMMLScene<StandaloneTagDebugAdapter>({
+      showDebugLoading: this.showDebugLoading,
+    });
     document.body.append(fullScreenMMLScene.element);
     const graphicsAdapter = await StandaloneTagDebugAdapter.create(fullScreenMMLScene.element);
     if (this.disposed) {

--- a/packages/mml-viewer/src/ThreeJSMode.ts
+++ b/packages/mml-viewer/src/ThreeJSMode.ts
@@ -1,6 +1,7 @@
 import { FormIteration } from "./FormIteration";
 import { GraphicsMode } from "./GraphicsMode";
 import { MMLSourceDefinition } from "./MMLSourceDefinition";
+import { ThreeJSModeOptions } from "./ThreeJSModeInternal";
 
 export class ThreeJSMode implements GraphicsMode {
   private disposed = false;
@@ -13,7 +14,7 @@ export class ThreeJSMode implements GraphicsMode {
     private targetForWrappers: HTMLElement,
     private mmlSource: MMLSourceDefinition,
     private formIteration: FormIteration,
-    private showDebugLoading: boolean,
+    private options: ThreeJSModeOptions,
   ) {
     this.init();
   }
@@ -33,7 +34,7 @@ export class ThreeJSMode implements GraphicsMode {
         this.targetForWrappers,
         this.mmlSource,
         this.formIteration,
-        this.showDebugLoading,
+        this.options,
       );
     })();
     if (this.disposed) {

--- a/packages/mml-viewer/src/ThreeJSMode.ts
+++ b/packages/mml-viewer/src/ThreeJSMode.ts
@@ -18,6 +18,13 @@ export class ThreeJSMode implements GraphicsMode {
     this.init();
   }
 
+  public updateSource(source: MMLSourceDefinition): void {
+    this.mmlSource = source;
+    if (this.internalMode) {
+      this.internalMode.updateSource(source);
+    }
+  }
+
   private async init() {
     this.internalMode = await (async () => {
       const { ThreeJSModeInternal } = await import("./ThreeJSModeInternal");

--- a/packages/mml-viewer/src/ThreeJSModeInternal.ts
+++ b/packages/mml-viewer/src/ThreeJSModeInternal.ts
@@ -63,6 +63,27 @@ export class ThreeJSModeInternal {
     this.init();
   }
 
+  public updateSource(source: MMLSourceDefinition): void {
+    this.mmlSourceDefinition = source;
+    if (this.loadedState) {
+      const existingSource = this.loadedState.mmlNetworkSource;
+      existingSource.dispose();
+      this.loadedState.mmlNetworkSource = MMLNetworkSource.create({
+        mmlScene: this.loadedState.fullScreenMMLScene,
+        statusUpdated: (status: NetworkedDOMWebsocketStatus) => {
+          this.loadedState?.statusUI.setStatus(NetworkedDOMWebsocketStatusToString(status));
+        },
+        url: source.url,
+        windowTarget: this.windowTarget,
+        targetForWrappers: this.targetForWrappers,
+      });
+      setDebugGlobals({
+        mmlScene: this.loadedState.fullScreenMMLScene,
+        remoteDocumentWrapper: this.loadedState.mmlNetworkSource.remoteDocumentWrapper,
+      });
+    }
+  }
+
   private async init() {
     const fullScreenMMLScene = new FullScreenMMLScene<StandaloneThreeJSAdapter>(
       this.showDebugLoading,

--- a/packages/mml-viewer/src/ThreeJSModeInternal.ts
+++ b/packages/mml-viewer/src/ThreeJSModeInternal.ts
@@ -38,6 +38,12 @@ import {
   environmentMapField,
 } from "./ui/fields";
 
+export type ThreeJSModeOptions = {
+  showDebugLoading?: boolean;
+  hideUntilLoaded?: boolean;
+  loadingStyle?: "bar" | "spinner";
+};
+
 export class ThreeJSModeInternal {
   private disposed = false;
 
@@ -58,7 +64,7 @@ export class ThreeJSModeInternal {
     private targetForWrappers: HTMLElement,
     private mmlSourceDefinition: MMLSourceDefinition,
     private formIteration: FormIteration,
-    private showDebugLoading: boolean,
+    private options: ThreeJSModeOptions,
   ) {
     this.init();
   }
@@ -66,6 +72,9 @@ export class ThreeJSModeInternal {
   public updateSource(source: MMLSourceDefinition): void {
     this.mmlSourceDefinition = source;
     if (this.loadedState) {
+      if (this.options.hideUntilLoaded) {
+        this.loadedState.graphicsAdapter.disconnectRoot();
+      }
       const existingSource = this.loadedState.mmlNetworkSource;
       existingSource.dispose();
 
@@ -76,6 +85,7 @@ export class ThreeJSModeInternal {
         this.loadedState.graphicsAdapter,
       );
       this.loadedState.mmlNetworkSource = mmlNetworkSource;
+      this.loadedState.fullScreenMMLScene.resetLoadingProgressBar();
     }
   }
 
@@ -104,15 +114,25 @@ export class ThreeJSModeInternal {
     });
     const loadingCallback = () => {
       const [, completedLoading] = fullScreenMMLScene.getLoadingProgressManager().toRatio();
+
+      /*
+       Attempt to apply the character animation as soon as the possible element exists so that the animation
+       counts towards the loading progress.
+      */
+      this.applyCharacterAnimation(this.formIteration.getFieldValue(characterAnimationField));
       if (completedLoading) {
         fullScreenMMLScene.getLoadingProgressManager().removeProgressCallback(loadingCallback);
+
+        if (this.options.hideUntilLoaded) {
+          requestAnimationFrame(() => {
+            this.loadedState?.graphicsAdapter.connectRoot();
+          });
+        }
 
         const fitContent = this.formIteration.getFieldValue(cameraFitContents);
         if (fitContent === "true") {
           graphicsAdapter.controls?.fitContent(calculateContentBounds(this.targetForWrappers));
         }
-
-        this.applyCharacterAnimation(this.formIteration.getFieldValue(characterAnimationField));
       }
     };
     fullScreenMMLScene.getLoadingProgressManager().addProgressCallback(loadingCallback);
@@ -120,12 +140,14 @@ export class ThreeJSModeInternal {
   }
 
   private async init() {
-    const fullScreenMMLScene = new FullScreenMMLScene<StandaloneThreeJSAdapter>(
-      this.showDebugLoading,
-    );
+    const fullScreenMMLScene = new FullScreenMMLScene<StandaloneThreeJSAdapter>({
+      showDebugLoading: this.options.showDebugLoading,
+      loadingStyle: this.options.loadingStyle,
+    });
     document.body.append(fullScreenMMLScene.element);
     const graphicsAdapter = await StandaloneThreeJSAdapter.create(fullScreenMMLScene.element, {
       controlsType: StandaloneThreeJSAdapterControlsType.DragFly,
+      autoConnectRoot: !this.options.hideUntilLoaded,
     });
     if (this.disposed) {
       graphicsAdapter.dispose();
@@ -323,14 +345,15 @@ export class ThreeJSModeInternal {
     }
   }
 
-  private applyCharacterAnimation(animation: string) {
+  private applyCharacterAnimation(animation: string): boolean {
     // This is the root tag of the MML scene
     const mmlRoot =
       this.loadedState?.mmlNetworkSource.remoteDocumentWrapper.remoteDocument.children[0]
         ?.children[0];
 
     if (mmlRoot) {
-      applyCharacterAnimation(mmlRoot, animation);
+      return applyCharacterAnimation(mmlRoot, animation);
     }
+    return false;
   }
 }

--- a/packages/mml-viewer/src/characterAnimation.ts
+++ b/packages/mml-viewer/src/characterAnimation.ts
@@ -1,7 +1,8 @@
-export function applyCharacterAnimation(mmlRoot: Element, animation: string) {
+// Returns true if a new animation was applied, false if the animation was cleared or unchanged.
+export function applyCharacterAnimation(mmlRoot: Element, animation: string): boolean {
   // If the root tag is not an m-character, we don't have a character to animate
   if (!mmlRoot || mmlRoot.tagName.toString() !== "M-CHARACTER") {
-    return;
+    return false;
   }
 
   // Store the original animation attribute so we can restore it later if the animation field is cleared
@@ -9,16 +10,22 @@ export function applyCharacterAnimation(mmlRoot: Element, animation: string) {
   const originalAnimation = mmlRoot.getAttribute(originalAnimationAttr);
   const currentAnimation = mmlRoot.getAttribute("anim");
   if (animation) {
+    // There is an animation to apply
     if (!originalAnimation) {
       mmlRoot.setAttribute(originalAnimationAttr, currentAnimation || "");
     }
     if (currentAnimation !== animation) {
       mmlRoot.setAttribute("anim", animation);
+      return true;
     }
   } else {
+    // There is no animation to apply
     if (originalAnimation) {
+      // There was an original animation, so we restore it
       mmlRoot.setAttribute("anim", originalAnimation);
       mmlRoot.removeAttribute(originalAnimationAttr);
+      return true;
     }
   }
+  return false;
 }

--- a/packages/mml-viewer/src/ui/FieldDefinition.ts
+++ b/packages/mml-viewer/src/ui/FieldDefinition.ts
@@ -1,7 +1,7 @@
 export type FieldDefinition = {
   readonly name: string;
   readonly label: string;
-  readonly type: string;
+  readonly type: "string" | "number" | "x,y,z" | "color" | "boolean";
   readonly requireSubmission?: boolean;
   readonly options?: string[];
   readonly defaultValue: string | number | boolean;

--- a/packages/mml-viewer/src/ui/UIField.ts
+++ b/packages/mml-viewer/src/ui/UIField.ts
@@ -76,6 +76,8 @@ export class UIField extends UIElement {
         this.input.type = "number";
       } else if (fieldDefinition.type === "color") {
         this.input.type = "text";
+      } else if (fieldDefinition.type === "boolean") {
+        this.input.type = "checkbox";
       } else {
         this.input.type = "text";
       }
@@ -97,6 +99,10 @@ export class UIField extends UIElement {
         if (this.input) {
           const input = this.input;
           this.input.addEventListener("input", () => {
+            if (input.type === "checkbox") {
+              this.onChange(input.checked ? "true" : "false");
+              return;
+            }
             this.onChange(input.value);
           });
         } else if (this.selectElement) {
@@ -119,11 +125,18 @@ export class UIField extends UIElement {
     if (this.selectElement) {
       this.selectElement.value = value;
     } else if (this.input) {
-      this.input.value = value;
+      if (this.input.type === "checkbox") {
+        this.input.checked = value === "true";
+      } else {
+        this.input.value = value;
+      }
     }
   }
 
   onChange(value: string) {
+    if (this.fieldDefinition.type === "boolean") {
+      value = value === "true" || value === "on" || value === "1" ? "true" : "false";
+    }
     setUrlParam(this.fieldDefinition.name, value);
   }
 }

--- a/packages/mml-viewer/src/ui/fields.ts
+++ b/packages/mml-viewer/src/ui/fields.ts
@@ -30,6 +30,11 @@ export const characterGroup: GroupDefinition = {
   label: "Character",
 };
 
+export const loadingGroup: GroupDefinition = {
+  name: "loading",
+  label: "Loading",
+};
+
 export const allGroups = [
   sourceGroup,
   rendererGroup,
@@ -37,6 +42,7 @@ export const allGroups = [
   lightGroup,
   environmentGroup,
   characterGroup,
+  loadingGroup,
 ];
 
 export const cameraModeField: FieldDefinition = {
@@ -114,6 +120,23 @@ export const urlField: FieldDefinition = {
   groupDefinition: sourceGroup,
 };
 
+export const loadingStyleField: FieldDefinition = {
+  name: "loadingStyle",
+  label: "Loading Style",
+  type: "string",
+  options: ["bar", "spinner"],
+  defaultValue: "bar",
+  groupDefinition: loadingGroup,
+};
+
+export const hideUntilLoadedField: FieldDefinition = {
+  name: "hideUntilLoaded",
+  label: "Hide Until Loaded",
+  type: "boolean",
+  defaultValue: false,
+  groupDefinition: loadingGroup,
+};
+
 export const rendererField: FieldDefinition = {
   name: "renderer",
   label: "Renderer",
@@ -176,6 +199,7 @@ export const allFields = [
   cameraFovField,
   environmentMapField,
   urlField,
+  loadingStyleField,
   rendererField,
   backgroundColorField,
   ambientLightField,

--- a/packages/mml-web-playcanvas-standalone/src/StandalonePlayCanvasAdapter.ts
+++ b/packages/mml-web-playcanvas-standalone/src/StandalonePlayCanvasAdapter.ts
@@ -32,6 +32,7 @@ export enum StandalonePlayCanvasAdapterControlsType {
 
 export type StandalonePlayCanvasAdapterOptions = {
   controlsType?: StandalonePlayCanvasAdapterControlsType;
+  autoConnectRoot?: boolean;
 };
 
 export class StandalonePlayCanvasAdapter
@@ -45,6 +46,8 @@ export class StandalonePlayCanvasAdapter
   public controls: PlayCanvasControls | null = null;
   private camera: playcanvas.Entity;
   private canvas: HTMLCanvasElement | null = null;
+
+  private contentRoot: playcanvas.Entity;
 
   private clickTrigger: PlayCanvasClickTrigger;
 
@@ -153,7 +156,12 @@ export class StandalonePlayCanvasAdapter
       clearColor: new playcanvas.Color(1, 1, 1, 1),
     } as playcanvas.CameraComponent);
     this.camera.setPosition(0, 5, 10);
-    this.playcanvasApp.root.addChild(this.camera);
+    this.contentRoot = new playcanvas.Entity("contentRoot", this.playcanvasApp);
+    this.contentRoot.addChild(this.camera);
+
+    if (this.options.autoConnectRoot === undefined || this.options.autoConnectRoot) {
+      this.playcanvasApp.root.addChild(this.contentRoot);
+    }
 
     this.setControlsType(this.options.controlsType);
 
@@ -234,8 +242,20 @@ export class StandalonePlayCanvasAdapter
     this.clickTrigger.dispose();
   }
 
+  disconnectRoot() {
+    if (this.contentRoot.parent) {
+      this.contentRoot.parent.removeChild(this.contentRoot);
+    }
+  }
+
+  connectRoot() {
+    if (!this.contentRoot.parent) {
+      this.playcanvasApp.root.addChild(this.contentRoot);
+    }
+  }
+
   getRootContainer() {
-    return this.playcanvasApp.root;
+    return this.contentRoot;
   }
 
   public getBoundingBoxForElement(element: HTMLElement): {

--- a/packages/mml-web-threejs-standalone/src/StandaloneThreeJSAdapter.ts
+++ b/packages/mml-web-threejs-standalone/src/StandaloneThreeJSAdapter.ts
@@ -25,6 +25,7 @@ export enum StandaloneThreeJSAdapterControlsType {
 
 export type StandaloneThreeJSAdapterOptions = {
   controlsType?: StandaloneThreeJSAdapterControlsType;
+  autoConnectRoot?: boolean;
 };
 
 export class StandaloneThreeJSAdapter implements ThreeJSGraphicsAdapter, StandaloneGraphicsAdapter {
@@ -84,7 +85,9 @@ export class StandaloneThreeJSAdapter implements ThreeJSGraphicsAdapter, Standal
     return new Promise<void>((resolve) => {
       this.rootContainer = new THREE.Group();
       this.threeScene = new THREE.Scene();
-      this.threeScene.add(this.rootContainer);
+      if (this.options.autoConnectRoot === undefined || this.options.autoConnectRoot) {
+        this.threeScene.add(this.rootContainer);
+      }
 
       this.camera = new THREE.PerspectiveCamera(
         75,
@@ -165,6 +168,18 @@ export class StandaloneThreeJSAdapter implements ThreeJSGraphicsAdapter, Standal
     }
     renderer.domElement.style.pointerEvents = "none";
     return renderer;
+  }
+
+  disconnectRoot() {
+    if (this.rootContainer.parent) {
+      this.rootContainer.parent.remove(this.rootContainer);
+    }
+  }
+
+  connectRoot() {
+    if (!this.rootContainer.parent) {
+      this.threeScene.add(this.rootContainer);
+    }
   }
 
   start() {

--- a/packages/mml-web/src/loading/LoadingProgressBar.ts
+++ b/packages/mml-web/src/loading/LoadingProgressBar.ts
@@ -14,6 +14,7 @@ export class LoadingProgressBar {
   private debugCheckbox: HTMLInputElement;
 
   private hasCompleted = false;
+  private disposed = false;
   private loadingCallback: () => void;
 
   constructor(
@@ -126,6 +127,10 @@ export class LoadingProgressBar {
   }
 
   public dispose() {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
     this.loadingProgressManager.removeProgressCallback(this.loadingCallback);
     this.element.remove();
   }

--- a/packages/mml-web/src/loading/LoadingSpinner.ts
+++ b/packages/mml-web/src/loading/LoadingSpinner.ts
@@ -1,0 +1,65 @@
+import { LoadingProgressManager } from "./LoadingProgressManager";
+
+export class LoadingSpinner {
+  public readonly element: HTMLDivElement;
+
+  private progressBarHolder: HTMLDivElement;
+  private progressBar: HTMLDivElement;
+
+  private hasCompleted = false;
+  private disposed = false;
+  private loadingCallback: () => void;
+
+  constructor(private loadingProgressManager: LoadingProgressManager) {
+    this.element = document.createElement("div");
+
+    this.progressBarHolder = document.createElement("div");
+    this.progressBarHolder.style.position = "absolute";
+    this.progressBarHolder.style.top = "50%";
+    this.progressBarHolder.style.left = "50%";
+    this.progressBarHolder.style.transform = "translate(-50%, -50%)";
+    this.progressBarHolder.style.width = "60px";
+    this.progressBarHolder.style.height = "60px";
+    this.element.append(this.progressBarHolder);
+
+    this.progressBar = document.createElement("div");
+    this.progressBar.style.position = "absolute";
+    this.progressBar.style.top = "0";
+    this.progressBar.style.left = "0";
+    this.progressBar.style.width = "100%";
+    this.progressBar.style.height = "100%";
+    this.progressBar.style.border = "6px solid #f3f3f3";
+    this.progressBar.style.borderTop = "6px solid rgba(0, 0, 0, 0)";
+    this.progressBar.style.borderRadius = "50%";
+    this.progressBarHolder.append(this.progressBar);
+
+    this.progressBar.animate([{ transform: "rotate(0deg)" }, { transform: "rotate(360deg)" }], {
+      duration: 1000,
+      iterations: Infinity,
+    });
+
+    this.loadingCallback = () => {
+      const [, completedLoading] = this.loadingProgressManager.toRatio();
+      if (completedLoading) {
+        if (!this.hasCompleted) {
+          this.hasCompleted = true;
+          this.dispose();
+        }
+        this.progressBar.style.display = "none";
+      } else {
+        this.progressBar.style.display = "block";
+      }
+    };
+
+    this.loadingProgressManager.addProgressCallback(this.loadingCallback);
+  }
+
+  public dispose() {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.loadingProgressManager.removeProgressCallback(this.loadingCallback);
+    this.element.remove();
+  }
+}

--- a/packages/mml-web/src/loading/index.ts
+++ b/packages/mml-web/src/loading/index.ts
@@ -1,3 +1,4 @@
 export * from "./LoadingInstanceManager";
 export * from "./LoadingProgressBar";
 export * from "./LoadingProgressManager";
+export * from "./LoadingSpinner";

--- a/packages/mml-web/src/scene/FullScreenMMLScene.ts
+++ b/packages/mml-web/src/scene/FullScreenMMLScene.ts
@@ -1,25 +1,46 @@
 import { StandaloneGraphicsAdapter } from "../graphics";
-import { LoadingProgressBar } from "../loading";
+import { LoadingProgressBar, LoadingSpinner } from "../loading";
 import { MMLScene } from "./MMLScene";
 
+export type FullScreenMMLSceneOptions = {
+  showDebugLoading?: boolean;
+  loadingStyle?: "bar" | "spinner";
+};
+
 export class FullScreenMMLScene<G extends StandaloneGraphicsAdapter> extends MMLScene<G> {
-  private loadingProgressBar: LoadingProgressBar;
+  private loadingProgressBar: LoadingProgressBar | LoadingSpinner;
   private showDebugLoading: boolean;
 
-  constructor(showDebugLoading = true) {
+  constructor(private options: FullScreenMMLSceneOptions = {}) {
     super(document.createElement("div"));
     this.element = document.createElement("div");
     this.element.style.width = "100%";
     this.element.style.height = "100%";
     this.element.style.position = "relative";
 
-    this.showDebugLoading = showDebugLoading;
-
-    const loadingProgressManager = this.getLoadingProgressManager();
-    this.loadingProgressBar = new LoadingProgressBar(loadingProgressManager, this.showDebugLoading);
-    this.element.append(this.loadingProgressBar.element);
+    this.showDebugLoading = options.showDebugLoading || true;
+    this.createLoadingProgressBar();
 
     this.configureWindowStyling();
+  }
+
+  private createLoadingProgressBar() {
+    const loadingProgressManager = this.getLoadingProgressManager();
+    const loadingStyle = this.options.loadingStyle || "bar";
+    if (loadingStyle === "spinner") {
+      this.loadingProgressBar = new LoadingSpinner(loadingProgressManager);
+    } else {
+      this.loadingProgressBar = new LoadingProgressBar(
+        loadingProgressManager,
+        this.showDebugLoading,
+      );
+    }
+    this.element.append(this.loadingProgressBar.element);
+  }
+
+  public resetLoadingProgressBar() {
+    this.loadingProgressBar.dispose();
+    this.createLoadingProgressBar();
   }
 
   private configureWindowStyling() {


### PR DESCRIPTION
This PR:
* adds more loading config options to the MML Viewer ([https://viewer.mml.io/](https://viewer.mml.io/))
  * `loadingStyle` - allows `bar` or `spinner` (default remains as `bar`)
  * `hideUntilLoaded` - allows hiding the MML content until it has fully loaded - `boolean` (defaults to `false`)
* adds a postMessage handler to the viewer to allow the parent frame to update the url parameters
  * sending: `{"type": "updateParams", "params": {"url": "https://[...]", "cameraOrbitSpeed": 10}}` as a postMessage to the page will update the url with the specified params.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
