### PR TITLE
fix: disable loading indicator when noUI=true

### DIFF
--- a/packages/mml-web/src/loading/LoadingProgressBar.ts
+++ b/packages/mml-web/src/loading/LoadingProgressBar.ts
@@ -17,10 +17,7 @@ export class LoadingProgressBar {
   private disposed = false;
   private loadingCallback: () => void;
 
-  constructor(
-    private loadingProgressManager: LoadingProgressManager,
-    private showDebugLoading: boolean,
-  ) {
+  constructor(private loadingProgressManager: LoadingProgressManager) {
     this.element = document.createElement("div");
     this.element.addEventListener("click", (event) => {
       event.stopPropagation();
@@ -62,9 +59,7 @@ export class LoadingProgressBar {
     this.debugLabel.style.display = "inline-block";
     this.debugLabel.style.userSelect = "none";
     this.debugLabel.append(this.debugCheckbox);
-    if (this.showDebugLoading) {
-      this.progressDebugView.append(this.debugLabel);
-    }
+    this.progressDebugView.append(this.debugLabel);
 
     this.progressDebugElement = document.createElement("pre");
     this.progressDebugElement.style.margin = "0";

--- a/packages/mml-web/src/scene/FullScreenMMLScene.ts
+++ b/packages/mml-web/src/scene/FullScreenMMLScene.ts
@@ -18,8 +18,11 @@ export class FullScreenMMLScene<G extends StandaloneGraphicsAdapter> extends MML
     this.element.style.height = "100%";
     this.element.style.position = "relative";
 
-    this.showDebugLoading = options.showDebugLoading || true;
-    this.createLoadingProgressBar();
+    this.showDebugLoading = options.showDebugLoading ?? true;
+
+    if (this.showDebugLoading) {
+      this.createLoadingProgressBar();
+    }
 
     this.configureWindowStyling();
   }
@@ -30,17 +33,16 @@ export class FullScreenMMLScene<G extends StandaloneGraphicsAdapter> extends MML
     if (loadingStyle === "spinner") {
       this.loadingProgressBar = new LoadingSpinner(loadingProgressManager);
     } else {
-      this.loadingProgressBar = new LoadingProgressBar(
-        loadingProgressManager,
-        this.showDebugLoading,
-      );
+      this.loadingProgressBar = new LoadingProgressBar(loadingProgressManager);
     }
     this.element.append(this.loadingProgressBar.element);
   }
 
   public resetLoadingProgressBar() {
     this.loadingProgressBar.dispose();
-    this.createLoadingProgressBar();
+    if (this.showDebugLoading) {
+      this.createLoadingProgressBar();
+    }
   }
 
   private configureWindowStyling() {


### PR DESCRIPTION
Fixes a bug that always showed the loading indicator, even when noUI is set to true (added in #231)

Also removes `showDebugLoading` param from `LoadingProgressBar` since the MMLScene can handle conditional initiailization of the progress bar. Hopefully simplifying the code


---

**What kind of changes does your PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
