### PR TITLE
fix: m-label collisions

### DIFF
--- a/packages/mml-web/src/elements/Label.ts
+++ b/packages/mml-web/src/elements/Label.ts
@@ -75,6 +75,7 @@ export class Label<G extends GraphicsAdapter = GraphicsAdapter> extends Transfor
       (newValue: number) => {
         this.props.width = newValue;
         this.labelGraphics?.setWidth(this.props.width, this.props);
+        this.collideableHelper.updateCollider(this.labelGraphics?.getCollisionElement());
       },
     ],
     height: [
@@ -83,6 +84,7 @@ export class Label<G extends GraphicsAdapter = GraphicsAdapter> extends Transfor
       (newValue: number) => {
         this.props.height = newValue;
         this.labelGraphics?.setHeight(this.props.height, this.props);
+        this.collideableHelper.updateCollider(this.labelGraphics?.getCollisionElement());
       },
     ],
     padding: [
@@ -184,7 +186,11 @@ export class Label<G extends GraphicsAdapter = GraphicsAdapter> extends Transfor
   }
 
   static get observedAttributes(): Array<string> {
-    return [...TransformableElement.observedAttributes, ...Label.attributeHandler.getAttributes()];
+    return [
+      ...TransformableElement.observedAttributes,
+      ...Label.attributeHandler.getAttributes(),
+      ...CollideableHelper.observedAttributes,
+    ];
   }
 
   constructor() {

--- a/packages/schema/src/schema-src/mml.xsd
+++ b/packages/schema/src/schema-src/mml.xsd
@@ -1124,6 +1124,7 @@
         <xs:extension base="MMLContent">
           <xs:attributeGroup ref="debuggable"/>
           <xs:attributeGroup ref="transformable"/>
+          <xs:attributeGroup ref="collideable"/>
           <xs:attributeGroup ref="colorable"/>
           <xs:attributeGroup ref="coreattrs"/>
           <xs:attributeGroup ref="clickable"/>


### PR DESCRIPTION
This PR fixes an issue where the `collide` attribute would not be observed on `m-label` and fixes observation of `width` and `height` affecting the collision geometry.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
