### PR TITLE
removes accidental usage of THREE in the mml-web package

### DIFF
--- a/packages/mml-web/src/elements/Label.ts
+++ b/packages/mml-web/src/elements/Label.ts
@@ -1,5 +1,3 @@
-import * as THREE from "three";
-
 import { AnimatedAttributeHelper } from "../attribute-animation";
 import {
   AttributeHandler,
@@ -56,7 +54,7 @@ export class Label<G extends GraphicsAdapter = GraphicsAdapter> extends Transfor
     color: [
       AnimationType.Color,
       defaultLabelColor,
-      (newValue: THREE.Color) => {
+      (newValue: MMLColor) => {
         this.props.color = newValue;
         this.labelGraphics?.setColor(this.props.color, this.props);
       },
@@ -64,7 +62,7 @@ export class Label<G extends GraphicsAdapter = GraphicsAdapter> extends Transfor
     "font-color": [
       AnimationType.Color,
       defaultFontColor,
-      (newValue: THREE.Color) => {
+      (newValue: MMLColor) => {
         this.props.fontColor = newValue;
         this.labelGraphics?.setFontColor(this.props.fontColor, this.props);
       },


### PR DESCRIPTION
This PR fixes the accidental usage of THREE in the `mml-web` package.

---

**What kind of changes does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [X] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
