### PR TITLE
feat: (Auth) connection token

### DIFF
--- a/integration-tests/networked-dom-integration-tests/test/TestCaseNetworkedDOMClient.ts
+++ b/integration-tests/networked-dom-integration-tests/test/TestCaseNetworkedDOMClient.ts
@@ -2,7 +2,7 @@ import {
   BufferReader,
   decodeServerMessages,
   networkedDOMProtocolSubProtocol_v0_1,
-  networkedDOMProtocolSubProtocol_v0_2,
+  networkedDOMProtocolSubProtocol_v0_2_1,
   NetworkedDOMV01ServerMessage,
   NetworkedDOMV02ServerMessage,
 } from "@mml-io/networked-dom-protocol";
@@ -20,7 +20,7 @@ export class TestCaseNetworkedDOMClient {
 
   constructor(useV01 = false) {
     this.fakeWebSocket = new FakeWebsocket(
-      useV01 ? networkedDOMProtocolSubProtocol_v0_1 : networkedDOMProtocolSubProtocol_v0_2,
+      useV01 ? networkedDOMProtocolSubProtocol_v0_1 : networkedDOMProtocolSubProtocol_v0_2_1,
     );
     this.fakeWebSocket.clientSideWebsocket.addEventListener("message", (evt: MessageEvent) => {
       this.allClientMessages.push(evt.data);

--- a/packages/mml-web-client/src/index.ts
+++ b/packages/mml-web-client/src/index.ts
@@ -58,6 +58,8 @@ declare global {
     scriptUrl.searchParams.get("allowOverlay") === "true" ||
     urlSearchParams.get("allowOverlay") === "true";
 
+  const connectionToken: string | null = urlSearchParams.get("token") ?? null;
+
   const fullScreenMMLSceneOptions: FullScreenMMLSceneOptions = {
     allowOverlay,
   };
@@ -77,12 +79,6 @@ declare global {
     const graphicsAdapter = await getGraphicsAdapter(fullScreenMMLScene.element);
 
     fullScreenMMLScene.init(graphicsAdapter);
-
-    const searchParams = new URL(window.location.href).searchParams;
-
-    const useIframe = searchParams.get("iframe") === "true";
-
-    const connectionToken: string | null = searchParams.get("token") ?? null;
 
     let targetForWrappers: HTMLElement;
     let windowTarget: Window;

--- a/packages/mml-web-client/src/index.ts
+++ b/packages/mml-web-client/src/index.ts
@@ -78,6 +78,12 @@ declare global {
 
     fullScreenMMLScene.init(graphicsAdapter);
 
+    const searchParams = new URL(window.location.href).searchParams;
+
+    const useIframe = searchParams.get("iframe") === "true";
+
+    const connectionToken: string | null = searchParams.get("token") ?? null;
+
     let targetForWrappers: HTMLElement;
     let windowTarget: Window;
 
@@ -95,6 +101,7 @@ declare global {
 
     const mmlNetworkSource = MMLNetworkSource.create({
       url,
+      connectionToken,
       mmlScene: fullScreenMMLScene,
       statusUpdated: (status: NetworkedDOMWebsocketStatus) => {
         if (status === NetworkedDOMWebsocketStatus.Connected) {

--- a/packages/mml-web/src/network/MMLNetworkSource.ts
+++ b/packages/mml-web/src/network/MMLNetworkSource.ts
@@ -6,6 +6,7 @@ import { IMMLScene } from "../scene";
 
 export type MMLNetworkSourceOptions = {
   url: string;
+  connectionToken?: string | null;
   mmlScene: IMMLScene;
   statusUpdated: (status: NetworkedDOMWebsocketStatus) => void;
   windowTarget: Window;
@@ -66,6 +67,7 @@ export class MMLNetworkSource {
           tagPrefix: "m-",
           // If overlays are allowed, allow SVG elements to populate them
           allowSVGElements: this.options.allowOverlay,
+          connectionToken: this.options.connectionToken ?? null,
         },
       );
       this.websocket = websocket;

--- a/packages/networked-dom-document/src/NetworkedDOM.ts
+++ b/packages/networked-dom-document/src/NetworkedDOM.ts
@@ -280,11 +280,11 @@ export class NetworkedDOM {
     }
 
     for (const networkedDOMConnection of this.networkedDOMV02Connections) {
-      for (const connectionId of networkedDOMConnection.internalIdToExternalId.keys()) {
+      for (const [connectionId, token] of networkedDOMConnection.internalIdToToken) {
         if (connectionId >= this.currentConnectionId) {
           this.currentConnectionId = connectionId + 1;
         }
-        this.observableDOM.addConnectedUserId(connectionId);
+        this.observableDOM.addConnectedUserId(connectionId, token);
       }
     }
 
@@ -294,7 +294,7 @@ export class NetworkedDOM {
         networkedDOMConnection.initAsNewV01Connection();
       }
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.observableDOM.addConnectedUserId(networkedDOMConnection.internalConnectionId!);
+      this.observableDOM.addConnectedUserId(networkedDOMConnection.internalConnectionId!, null);
     }
 
     for (const networkedDOMConnection of this.networkedDOMV02Connections) {
@@ -423,8 +423,8 @@ export class NetworkedDOM {
         networkedDOMConnection.webSocket,
         networkedDOMConnection,
       );
-      for (const connectionId of networkedDOMConnection.internalIdToExternalId.keys()) {
-        this.observableDOM.addConnectedUserId(connectionId);
+      for (const [connectionId, token] of networkedDOMConnection.internalIdToToken) {
+        this.observableDOM.addConnectedUserId(connectionId, token);
       }
       networkedDOMConnection.sendMessage(
         this.getInitialV02Snapshot(networkedDOMConnection, documentVirtualDOMElement),
@@ -476,9 +476,9 @@ export class NetworkedDOM {
   }
 
   // Called by the connections after storing the mapping of connected users ids
-  public announceConnectedUsers(userIds: Set<number>) {
-    for (const userId of userIds) {
-      this.observableDOM.addConnectedUserId(userId);
+  public announceConnectedUsers(userIds: Map<number, string | null>) {
+    for (const [userId, token] of userIds) {
+      this.observableDOM.addConnectedUserId(userId, token);
     }
   }
 
@@ -520,6 +520,7 @@ export class NetworkedDOM {
       networkedDOMConnection.externalConnectionIds.delete(removingExternalId);
       networkedDOMConnection.externalIdToInternalId.delete(removingExternalId);
       networkedDOMConnection.internalIdToExternalId.delete(removingInternalId);
+      networkedDOMConnection.internalIdToToken.delete(removingInternalId);
       this.connectionIdToNetworkedDOMConnection.delete(removingInternalId);
     }
 

--- a/packages/networked-dom-document/src/NetworkedDOMV01Connection.ts
+++ b/packages/networked-dom-document/src/NetworkedDOMV01Connection.ts
@@ -63,7 +63,9 @@ export class NetworkedDOMV01Connection {
     const internalConnectionIds = this.networkedDOM.connectUsers(this, new Set([1]));
     this.internalConnectionId = internalConnectionIds.entries().next().value[0] as number;
     this.internalIdToExternalId.set(this.internalConnectionId, 1);
-    this.networkedDOM.announceConnectedUsers(new Set([this.internalConnectionId]));
+    this.networkedDOM.announceConnectedUsers(
+      new Map<number, string | null>([[this.internalConnectionId, null]]),
+    );
   }
 
   public stringifyAndSendSingleMessage(message: NetworkedDOMV01ServerMessage) {

--- a/packages/networked-dom-document/src/createNetworkedDOMConnectionForWebsocket.ts
+++ b/packages/networked-dom-document/src/createNetworkedDOMConnectionForWebsocket.ts
@@ -1,6 +1,9 @@
 import {
+  isNetworkedDOMProtocolSubProtocol_v0_2,
   networkedDOMProtocolSubProtocol_v0_1,
   networkedDOMProtocolSubProtocol_v0_2,
+  networkedDOMProtocolSubProtocol_v0_2_1,
+  networkedDOMProtocolSubProtocol_v0_2_SubVersionsList,
   NetworkedDOMV02ServerMessage,
 } from "@mml-io/networked-dom-protocol";
 
@@ -9,7 +12,7 @@ import { NetworkedDOMV02Connection } from "./NetworkedDOMV02Connection";
 
 // First to last in order of preference
 export const SupportedWebsocketSubProtocolsPreferenceOrder = [
-  networkedDOMProtocolSubProtocol_v0_2,
+  ...networkedDOMProtocolSubProtocol_v0_2_SubVersionsList,
   networkedDOMProtocolSubProtocol_v0_1,
 ] as const;
 
@@ -27,6 +30,7 @@ export function createNetworkedDOMConnectionForWebsocket(
   let assumedProtocol:
     | typeof networkedDOMProtocolSubProtocol_v0_1
     | typeof networkedDOMProtocolSubProtocol_v0_2
+    | typeof networkedDOMProtocolSubProtocol_v0_2_1
     | null = null;
   if (webSocket.protocol) {
     if (!IsRecognizedWebsocketSubProtocol(webSocket.protocol)) {
@@ -56,7 +60,7 @@ export function createNetworkedDOMConnectionForWebsocket(
     assumedProtocol = defaultWebsocketSubProtocol;
   }
 
-  const isV02 = assumedProtocol === networkedDOMProtocolSubProtocol_v0_2;
+  const isV02 = isNetworkedDOMProtocolSubProtocol_v0_2(assumedProtocol);
   if (isV02) {
     return new NetworkedDOMV02Connection(webSocket);
   }

--- a/packages/networked-dom-document/test/logging.test.ts
+++ b/packages/networked-dom-document/test/logging.test.ts
@@ -2,6 +2,7 @@ import { LocalObservableDOMFactory } from "@mml-io/networked-dom-server";
 import { LogMessage } from "@mml-io/observable-dom-common";
 
 import { EditableNetworkedDOM } from "../src";
+import { waitUntil } from "./waitUntil";
 
 let currentDoc: EditableNetworkedDOM | null = null;
 afterEach(() => {
@@ -10,28 +11,6 @@ afterEach(() => {
     currentDoc = null;
   }
 });
-
-function waitUntil(checkFn: () => boolean) {
-  return new Promise((resolve) => {
-    if (checkFn()) {
-      resolve(null);
-      return;
-    }
-
-    const interval = setInterval(() => {
-      if (checkFn()) {
-        clearInterval(interval);
-        clearTimeout(maxTimeout);
-        resolve(null);
-      }
-    }, 10);
-
-    const maxTimeout = setTimeout(() => {
-      clearInterval(interval);
-      resolve(null);
-    }, 3000);
-  });
-}
 
 describe("logging", () => {
   test("buffered console logging during document init", async () => {

--- a/packages/networked-dom-document/test/networked-dom-v02/connected-event-token.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/connected-event-token.test.ts
@@ -1,0 +1,388 @@
+import { LocalObservableDOMFactory } from "@mml-io/networked-dom-server";
+import { LogMessage } from "@mml-io/observable-dom-common";
+
+import { EditableNetworkedDOM } from "../../src";
+import { waitUntil } from "../waitUntil";
+import { MockWebsocketV02 } from "./mock.websocket-v02";
+
+let currentDoc: EditableNetworkedDOM | null = null;
+
+afterEach(() => {
+  if (currentDoc) {
+    currentDoc.dispose();
+    currentDoc = null;
+  }
+});
+
+describe("connected event token field - v0.2", () => {
+  test("client connects with token - MML code receives connected event with token", async () => {
+    const loggedMessages: Array<LogMessage> = [];
+
+    const doc = new EditableNetworkedDOM(
+      "file://test.html",
+      LocalObservableDOMFactory,
+      true,
+      (logMessage: LogMessage) => {
+        loggedMessages.push(logMessage);
+      },
+    );
+    currentDoc = doc;
+
+    doc.load(`
+<script>
+  window.addEventListener("connected", (event) => {
+    console.log("CONNECTED_EVENT:" + JSON.stringify({
+      connectionId: event.detail.connectionId,
+      connectionToken: event.detail.connectionToken
+    }));
+  });
+</script>`);
+
+    const clientWs = new MockWebsocketV02();
+    doc.addWebSocket(clientWs as unknown as WebSocket);
+
+    // Wait for initial snapshot
+    await clientWs.waitForTotalMessageCount(1);
+
+    // Connect with a token
+    clientWs.sendToServer({
+      type: "connectUsers",
+      connectionIds: [42],
+      connectionTokens: ["user-token-123"],
+    });
+
+    // Wait for the connected event to be logged
+    await waitUntil(() =>
+      loggedMessages.some(
+        (msg) =>
+          msg.content.length > 0 &&
+          typeof msg.content[0] === "string" &&
+          msg.content[0].includes("CONNECTED_EVENT:"),
+      ),
+    );
+
+    const connectedEventLog = loggedMessages.find(
+      (msg) =>
+        msg.content.length > 0 &&
+        typeof msg.content[0] === "string" &&
+        msg.content[0].includes("CONNECTED_EVENT:"),
+    );
+
+    expect(connectedEventLog).toBeDefined();
+
+    const eventDataString = connectedEventLog!.content[0] as string;
+    const eventData = JSON.parse(eventDataString.replace("CONNECTED_EVENT:", ""));
+
+    expect(eventData).toEqual({
+      connectionId: 1, // Internal connection ID (should be 1 for first connection)
+      connectionToken: "user-token-123",
+    });
+  });
+
+  test("client connects without token - MML code receives connected event with null token", async () => {
+    const loggedMessages: Array<LogMessage> = [];
+
+    const doc = new EditableNetworkedDOM(
+      "file://test.html",
+      LocalObservableDOMFactory,
+      true,
+      (logMessage: LogMessage) => {
+        loggedMessages.push(logMessage);
+      },
+    );
+    currentDoc = doc;
+
+    doc.load(`
+<script>
+  window.addEventListener("connected", (event) => {
+    console.log("CONNECTED_EVENT:" + JSON.stringify({
+      connectionId: event.detail.connectionId,
+      connectionToken: event.detail.connectionToken
+    }));
+  });
+</script>`);
+
+    const clientWs = new MockWebsocketV02();
+    doc.addWebSocket(clientWs as unknown as WebSocket);
+
+    // Wait for initial snapshot
+    await clientWs.waitForTotalMessageCount(1);
+
+    // Connect without a token (null)
+    clientWs.sendToServer({
+      type: "connectUsers",
+      connectionIds: [42],
+      connectionTokens: [null],
+    });
+
+    // Wait for the connected event to be logged
+    await waitUntil(() =>
+      loggedMessages.some(
+        (msg) =>
+          msg.content.length > 0 &&
+          typeof msg.content[0] === "string" &&
+          msg.content[0].includes("CONNECTED_EVENT:"),
+      ),
+    );
+
+    const connectedEventLog = loggedMessages.find(
+      (msg) =>
+        msg.content.length > 0 &&
+        typeof msg.content[0] === "string" &&
+        msg.content[0].includes("CONNECTED_EVENT:"),
+    );
+
+    expect(connectedEventLog).toBeDefined();
+
+    const eventDataString = connectedEventLog!.content[0] as string;
+    const eventData = JSON.parse(eventDataString.replace("CONNECTED_EVENT:", ""));
+
+    expect(eventData).toEqual({
+      connectionId: 1, // Internal connection ID
+      connectionToken: null,
+    });
+  });
+
+  test("multiple clients with different tokens - MML code receives separate connected events", async () => {
+    const loggedMessages: Array<LogMessage> = [];
+
+    const doc = new EditableNetworkedDOM(
+      "file://test.html",
+      LocalObservableDOMFactory,
+      true,
+      (logMessage: LogMessage) => {
+        loggedMessages.push(logMessage);
+      },
+    );
+    currentDoc = doc;
+
+    doc.load(`
+<script>
+  window.addEventListener("connected", (event) => {
+    console.log("CONNECTED_EVENT:" + JSON.stringify({
+      connectionId: event.detail.connectionId,
+      connectionToken: event.detail.connectionToken
+    }));
+  });
+</script>`);
+
+    // First client
+    const clientWs1 = new MockWebsocketV02();
+    doc.addWebSocket(clientWs1 as unknown as WebSocket);
+    await clientWs1.waitForTotalMessageCount(1);
+
+    clientWs1.sendToServer({
+      type: "connectUsers",
+      connectionIds: [100],
+      connectionTokens: ["token-client-1"],
+    });
+
+    // Wait for first connected event
+    await waitUntil(
+      () =>
+        loggedMessages.filter(
+          (msg) =>
+            msg.content.length > 0 &&
+            typeof msg.content[0] === "string" &&
+            msg.content[0].includes("CONNECTED_EVENT:"),
+        ).length >= 1,
+    );
+
+    // Second client
+    const clientWs2 = new MockWebsocketV02();
+    doc.addWebSocket(clientWs2 as unknown as WebSocket);
+    await clientWs2.waitForTotalMessageCount(1);
+
+    clientWs2.sendToServer({
+      type: "connectUsers",
+      connectionIds: [200],
+      connectionTokens: ["token-client-2"],
+    });
+
+    // Wait for second connected event
+    await waitUntil(
+      () =>
+        loggedMessages.filter(
+          (msg) =>
+            msg.content.length > 0 &&
+            typeof msg.content[0] === "string" &&
+            msg.content[0].includes("CONNECTED_EVENT:"),
+        ).length >= 2,
+    );
+
+    // Third client with no token
+    const clientWs3 = new MockWebsocketV02();
+    doc.addWebSocket(clientWs3 as unknown as WebSocket);
+    await clientWs3.waitForTotalMessageCount(1);
+
+    clientWs3.sendToServer({
+      type: "connectUsers",
+      connectionIds: [300],
+      connectionTokens: [null],
+    });
+
+    // Wait for third connected event
+    await waitUntil(
+      () =>
+        loggedMessages.filter(
+          (msg) =>
+            msg.content.length > 0 &&
+            typeof msg.content[0] === "string" &&
+            msg.content[0].includes("CONNECTED_EVENT:"),
+        ).length >= 3,
+    );
+
+    // Extract all connected event logs
+    const connectedEventLogs = loggedMessages.filter(
+      (msg) =>
+        msg.content.length > 0 &&
+        typeof msg.content[0] === "string" &&
+        msg.content[0].includes("CONNECTED_EVENT:"),
+    );
+
+    expect(connectedEventLogs).toHaveLength(3);
+
+    const connectedEvents = connectedEventLogs.map((log) => {
+      const eventDataString = log.content[0] as string;
+      return JSON.parse(eventDataString.replace("CONNECTED_EVENT:", ""));
+    });
+
+    expect(connectedEvents).toEqual([
+      { connectionId: 1, connectionToken: "token-client-1" },
+      { connectionId: 2, connectionToken: "token-client-2" },
+      { connectionId: 3, connectionToken: null },
+    ]);
+  });
+
+  test("client connects with multiple users and mixed tokens", async () => {
+    const loggedMessages: Array<LogMessage> = [];
+
+    const doc = new EditableNetworkedDOM(
+      "file://test.html",
+      LocalObservableDOMFactory,
+      true,
+      (logMessage: LogMessage) => {
+        loggedMessages.push(logMessage);
+      },
+    );
+    currentDoc = doc;
+
+    doc.load(`
+<script>
+  window.addEventListener("connected", (event) => {
+    console.log("CONNECTED_EVENT:" + JSON.stringify({
+      connectionId: event.detail.connectionId,
+      connectionToken: event.detail.connectionToken
+    }));
+  });
+</script>`);
+
+    const clientWs = new MockWebsocketV02();
+    doc.addWebSocket(clientWs as unknown as WebSocket);
+
+    // Wait for initial snapshot
+    await clientWs.waitForTotalMessageCount(1);
+
+    // Connect multiple users with mixed tokens
+    clientWs.sendToServer({
+      type: "connectUsers",
+      connectionIds: [101, 102, 103],
+      connectionTokens: ["user-token-a", null, "user-token-c"],
+    });
+
+    // Wait for all connected events to be logged
+    await waitUntil(
+      () =>
+        loggedMessages.filter(
+          (msg) =>
+            msg.content.length > 0 &&
+            typeof msg.content[0] === "string" &&
+            msg.content[0].includes("CONNECTED_EVENT:"),
+        ).length >= 3,
+    );
+
+    const connectedEventLogs = loggedMessages.filter(
+      (msg) =>
+        msg.content.length > 0 &&
+        typeof msg.content[0] === "string" &&
+        msg.content[0].includes("CONNECTED_EVENT:"),
+    );
+
+    expect(connectedEventLogs).toHaveLength(3);
+
+    const connectedEvents = connectedEventLogs.map((log) => {
+      const eventDataString = log.content[0] as string;
+      return JSON.parse(eventDataString.replace("CONNECTED_EVENT:", ""));
+    });
+
+    expect(connectedEvents).toEqual([
+      { connectionId: 1, connectionToken: "user-token-a" },
+      { connectionId: 2, connectionToken: null },
+      { connectionId: 3, connectionToken: "user-token-c" },
+    ]);
+  });
+
+  test("empty string token is treated as null", async () => {
+    const loggedMessages: Array<LogMessage> = [];
+
+    const doc = new EditableNetworkedDOM(
+      "file://test.html",
+      LocalObservableDOMFactory,
+      true,
+      (logMessage: LogMessage) => {
+        loggedMessages.push(logMessage);
+      },
+    );
+    currentDoc = doc;
+
+    doc.load(`
+<script>
+  window.addEventListener("connected", (event) => {
+    console.log("CONNECTED_EVENT:" + JSON.stringify({
+      connectionId: event.detail.connectionId,
+      connectionToken: event.detail.connectionToken
+    }));
+  });
+</script>`);
+
+    const clientWs = new MockWebsocketV02();
+    doc.addWebSocket(clientWs as unknown as WebSocket);
+
+    // Wait for initial snapshot
+    await clientWs.waitForTotalMessageCount(1);
+
+    // Connect with an empty string token (should be treated as null)
+    clientWs.sendToServer({
+      type: "connectUsers",
+      connectionIds: [42],
+      connectionTokens: [""], // Empty string should become null
+    });
+
+    // Wait for the connected event to be logged
+    await waitUntil(() =>
+      loggedMessages.some(
+        (msg) =>
+          msg.content.length > 0 &&
+          typeof msg.content[0] === "string" &&
+          msg.content[0].includes("CONNECTED_EVENT:"),
+      ),
+    );
+
+    const connectedEventLog = loggedMessages.find(
+      (msg) =>
+        msg.content.length > 0 &&
+        typeof msg.content[0] === "string" &&
+        msg.content[0].includes("CONNECTED_EVENT:"),
+    );
+
+    expect(connectedEventLog).toBeDefined();
+
+    const eventDataString = connectedEventLog!.content[0] as string;
+    const eventData = JSON.parse(eventDataString.replace("CONNECTED_EVENT:", ""));
+
+    expect(eventData).toEqual({
+      connectionId: 1,
+      connectionToken: null, // Empty string should be converted to null
+    });
+  });
+});

--- a/packages/networked-dom-document/test/networked-dom-v02/end-to-end.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/end-to-end.test.ts
@@ -206,6 +206,7 @@ describe("end to end - v0.2", () => {
     clientWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1],
+      connectionTokens: [null],
     });
 
     clientWs.sendToServer({
@@ -1023,8 +1024,8 @@ setTimeout(() => {
               {
                 attributes: [
                   /*
-                   This value should be "1" and not "2" at the point the node 
-                   is added, but the mutation observer does not observe this 
+                   This value should be "1" and not "2" at the point the node
+                   is added, but the mutation observer does not observe this
                    value before it is overwritten.
                   */
                   ["y", "2"],

--- a/packages/networked-dom-document/test/networked-dom-v02/filtering.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/filtering.test.ts
@@ -146,6 +146,7 @@ describe("filtering - v0.2", () => {
     clientWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1],
+      connectionTokens: [null],
     });
 
     const clickRedEvent: NetworkedDOMV02RemoteEvent = {

--- a/packages/networked-dom-document/test/networked-dom-v02/mock.websocket-v02.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/mock.websocket-v02.ts
@@ -3,13 +3,17 @@ import {
   BufferWriter,
   decodeServerMessages,
   encodeClientMessage,
-  networkedDOMProtocolSubProtocol_v0_2,
+  getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow,
+  networkedDOMProtocolSubProtocol_v0_2_1,
   NetworkedDOMV02ClientMessage,
   NetworkedDOMV02ServerMessage,
 } from "@mml-io/networked-dom-protocol";
 
 export class MockWebsocketV02 {
-  public readonly protocol = networkedDOMProtocolSubProtocol_v0_2;
+  public readonly protocol = networkedDOMProtocolSubProtocol_v0_2_1;
+  private protocolSubversion = getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow(
+    this.protocol,
+  );
   private allMessages: Array<NetworkedDOMV02ServerMessage> = [];
   private messageTriggers = new Set<() => void>();
   private serverMessageListeners = new Set<(message: MessageEvent) => void>();
@@ -69,7 +73,7 @@ export class MockWebsocketV02 {
 
   sendToServer(toSend: NetworkedDOMV02ClientMessage) {
     const writer = new BufferWriter(32);
-    encodeClientMessage(toSend, writer);
+    encodeClientMessage(toSend, writer, this.protocolSubversion);
     this.serverMessageListeners.forEach((listener) => {
       listener(
         new MessageEvent("message", {

--- a/packages/networked-dom-document/test/networked-dom-v02/multi-client-subjectivity.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/multi-client-subjectivity.test.ts
@@ -25,6 +25,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientOneWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 1
+      connectionTokens: [null],
     });
 
     const clientTwoWs = new MockWebsocketV02();
@@ -32,6 +33,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientTwoWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 2
+      connectionTokens: [null],
     });
 
     // Load only after the connections are established
@@ -202,6 +204,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientOneWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 1
+      connectionTokens: [null],
     });
 
     const clientTwoWs = new MockWebsocketV02();
@@ -209,6 +212,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientTwoWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 2
+      connectionTokens: [null],
     });
 
     // Load only after the connections are established
@@ -385,6 +389,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientOneWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 1
+      connectionTokens: [null],
     });
 
     const clientTwoWs = new MockWebsocketV02();
@@ -392,6 +397,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientTwoWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 2
+      connectionTokens: [null],
     });
 
     expect(await clientOneWs.waitForTotalMessageCount(1)).toEqual([
@@ -548,6 +554,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientOneWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 1
+      connectionTokens: [null],
     });
 
     const clientTwoWs = new MockWebsocketV02();
@@ -555,6 +562,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientTwoWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 2
+      connectionTokens: [null],
     });
 
     const clientThreeWs = new MockWebsocketV02();
@@ -562,6 +570,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientThreeWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 3
+      connectionTokens: [null],
     });
 
     expect(await clientOneWs.waitForTotalMessageCount(1)).toEqual([
@@ -758,6 +767,7 @@ describe("multi-client subjectivity - v0.2", () => {
     clientOneWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1, 2], // Should be internal id 1, 2
+      connectionTokens: [null, null],
     });
 
     // Load only after the connections are established

--- a/packages/networked-dom-document/test/networked-dom-v02/regression.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/regression.test.ts
@@ -37,6 +37,7 @@ describe("regression tests - v0.2", () => {
     clientOneWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 1
+      connectionTokens: [null],
     });
 
     expect(await clientOneWs.waitForTotalMessageCount(1)).toEqual([

--- a/packages/networked-dom-document/test/networked-dom-v02/reload.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/reload.test.ts
@@ -330,6 +330,7 @@ describe("reloading - v0.2", () => {
     clientWs.sendToServer({
       type: "connectUsers",
       connectionIds: [1], // Should be internal id 1
+      connectionTokens: [null],
     });
 
     expect(await clientWs.waitForTotalMessageCount(1)).toEqual([

--- a/packages/networked-dom-document/test/waitUntil.ts
+++ b/packages/networked-dom-document/test/waitUntil.ts
@@ -1,0 +1,21 @@
+export function waitUntil(checkFn: () => boolean) {
+  return new Promise((resolve) => {
+    if (checkFn()) {
+      resolve(null);
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (checkFn()) {
+        clearInterval(interval);
+        clearTimeout(maxTimeout);
+        resolve(null);
+      }
+    }, 10);
+
+    const maxTimeout = setTimeout(() => {
+      clearInterval(interval);
+      resolve(null);
+    }, 3000);
+  });
+}

--- a/packages/networked-dom-protocol/package.json
+++ b/packages/networked-dom-protocol/package.json
@@ -15,6 +15,8 @@
     "build": "tsx ./build.ts --build",
     "iterate": "tsx ./build.ts --watch",
     "lint": "eslint \"./**/*.{js,jsx,ts,tsx}\" --max-warnings 0",
-    "lint-fix": "eslint \"./**/*.{js,jsx,ts,tsx}\" --fix"
+    "lint-fix": "eslint \"./**/*.{js,jsx,ts,tsx}\" --fix",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "test-iterate": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --watch"
   }
 }

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/constants.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/constants.ts
@@ -1,1 +1,43 @@
 export const networkedDOMProtocolSubProtocol_v0_2 = "networked-dom-v0.2";
+export const networkedDOMProtocolSubProtocol_v0_2_1 = "networked-dom-v0.2.1";
+
+// In priority order, from most preferred to least preferred
+export const networkedDOMProtocolSubProtocol_v0_2_SubVersionsList = [
+  networkedDOMProtocolSubProtocol_v0_2_1,
+  networkedDOMProtocolSubProtocol_v0_2,
+] as const;
+
+export type networkedDOMProtocolSubProtocol_v0_2_Subversion =
+  (typeof networkedDOMProtocolSubProtocol_v0_2_SubVersionsList)[number];
+
+export type networkedDOMProtocolSubProtocol_v0_2_SubversionNumber = 0 | 1;
+
+const protocolSubVersionMap: Record<
+  networkedDOMProtocolSubProtocol_v0_2_Subversion,
+  networkedDOMProtocolSubProtocol_v0_2_SubversionNumber
+> = {
+  [networkedDOMProtocolSubProtocol_v0_2]: 0,
+  [networkedDOMProtocolSubProtocol_v0_2_1]: 1,
+};
+
+export function getNetworkedDOMProtocolSubProtocol_v0_2Subversion(
+  protocol: networkedDOMProtocolSubProtocol_v0_2_Subversion,
+): networkedDOMProtocolSubProtocol_v0_2_SubversionNumber | null {
+  return protocolSubVersionMap[protocol] ?? null;
+}
+
+export function getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow(
+  protocol: networkedDOMProtocolSubProtocol_v0_2_Subversion,
+): networkedDOMProtocolSubProtocol_v0_2_SubversionNumber {
+  const subversion = getNetworkedDOMProtocolSubProtocol_v0_2Subversion(protocol);
+  if (subversion === null) {
+    throw new Error(`Unrecognized networked-dom-v0.2 protocol subversion: ${protocol}`);
+  }
+  return subversion;
+}
+
+export function isNetworkedDOMProtocolSubProtocol_v0_2(
+  protocol: string,
+): protocol is (typeof networkedDOMProtocolSubProtocol_v0_2_SubVersionsList)[number] {
+  return networkedDOMProtocolSubProtocol_v0_2_SubVersionsList.includes(protocol as any);
+}

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/decodeClientMessages.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/decodeClientMessages.ts
@@ -1,4 +1,5 @@
 import { BufferReader } from "./BufferReader";
+import { networkedDOMProtocolSubProtocol_v0_2_SubversionNumber } from "./constants";
 import { NetworkedDOMV02ClientMessage } from "./messages";
 import { decodeConnectUsers } from "./messages/from-client/connectUsers";
 import { decodeDisconnectUsers } from "./messages/from-client/disconnectUsers";
@@ -11,13 +12,16 @@ import {
   PongMessageType,
 } from "./messageTypes";
 
-export function decodeClientMessages(buffer: BufferReader): Array<NetworkedDOMV02ClientMessage> {
+export function decodeClientMessages(
+  buffer: BufferReader,
+  protocolSubversion: networkedDOMProtocolSubProtocol_v0_2_SubversionNumber,
+): Array<NetworkedDOMV02ClientMessage> {
   const messages: NetworkedDOMV02ClientMessage[] = [];
   while (!buffer.isEnd()) {
     const messageType = buffer.readUInt8();
     switch (messageType) {
       case ConnectUsersMessageType:
-        messages.push(decodeConnectUsers(buffer));
+        messages.push(decodeConnectUsers(buffer, protocolSubversion));
         break;
       case DisconnectUsersMessageType:
         messages.push(decodeDisconnectUsers(buffer));

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/encodeClientMessage.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/encodeClientMessage.ts
@@ -1,4 +1,5 @@
 import { BufferWriter } from "./BufferWriter";
+import { networkedDOMProtocolSubProtocol_v0_2_SubversionNumber } from "./constants";
 import {
   encodeConnectUsers,
   encodeDisconnectUsers,
@@ -7,11 +8,15 @@ import {
   NetworkedDOMV02ClientMessage,
 } from "./messages";
 
-export function encodeClientMessage(message: NetworkedDOMV02ClientMessage, writer: BufferWriter) {
+export function encodeClientMessage(
+  message: NetworkedDOMV02ClientMessage,
+  writer: BufferWriter,
+  protocolSubversion: networkedDOMProtocolSubProtocol_v0_2_SubversionNumber,
+) {
   const type = message.type;
   switch (type) {
     case "connectUsers":
-      return encodeConnectUsers(message, writer);
+      return encodeConnectUsers(message, writer, protocolSubversion);
     case "disconnectUsers":
       return encodeDisconnectUsers(message, writer);
     case "event":

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/featureDetection.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/featureDetection.ts
@@ -1,0 +1,8 @@
+import { networkedDOMProtocolSubProtocol_v0_2_SubversionNumber } from "./constants";
+
+// Whether the given protocol subversion supports the `connectionTokens` field in the `connectUsers` message
+export function protocolSubversionHasConnectionTokens(
+  protocolSubversion: networkedDOMProtocolSubProtocol_v0_2_SubversionNumber,
+) {
+  return protocolSubversion >= 1;
+}

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/connectUsers.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/connectUsers.test.ts
@@ -1,0 +1,107 @@
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import {
+  getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow,
+  networkedDOMProtocolSubProtocol_v0_2,
+  networkedDOMProtocolSubProtocol_v0_2_1,
+  networkedDOMProtocolSubProtocol_v0_2_SubversionNumber,
+} from "../../constants";
+import { ConnectUsersMessageType } from "../../messageTypes";
+import {
+  decodeConnectUsers,
+  encodeConnectUsers,
+  NetworkedDOMV02ConnectUsersMessage,
+} from "./connectUsers";
+
+const cases: Array<
+  [
+    string,
+    NetworkedDOMV02ConnectUsersMessage,
+    networkedDOMProtocolSubProtocol_v0_2_SubversionNumber,
+    Array<number>,
+  ]
+> = [
+  [
+    "empty connection list",
+    {
+      type: "connectUsers",
+      connectionIds: [],
+      connectionTokens: [],
+    },
+    getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow(
+      networkedDOMProtocolSubProtocol_v0_2_1,
+    ),
+    [14, 0],
+  ],
+  [
+    "single connection without token (v0.2.0)",
+    {
+      type: "connectUsers",
+      connectionIds: [123],
+      connectionTokens: [null],
+    },
+    getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow(networkedDOMProtocolSubProtocol_v0_2),
+    [14, 1, 123],
+  ],
+  [
+    "single connection with null token (v0.2.1+)",
+    {
+      type: "connectUsers",
+      connectionIds: [123],
+      connectionTokens: [null],
+    },
+    getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow(
+      networkedDOMProtocolSubProtocol_v0_2_1,
+    ),
+    [14, 1, 123, 0],
+  ],
+  [
+    "single connection with token (v0.2.1+)",
+    {
+      type: "connectUsers",
+      connectionIds: [123],
+      connectionTokens: ["token123"],
+    },
+    getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow(
+      networkedDOMProtocolSubProtocol_v0_2_1,
+    ),
+    [14, 1, 123, 8, 116, 111, 107, 101, 110, 49, 50, 51],
+  ],
+  [
+    "multiple connections with mixed tokens (v0.2.1+)",
+    {
+      type: "connectUsers",
+      connectionIds: [123, 456, 789],
+      connectionTokens: ["token1", null, "token3"],
+    },
+    getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow(
+      networkedDOMProtocolSubProtocol_v0_2_1,
+    ),
+    [14, 3, 123, 200, 3, 149, 6, 6, 116, 111, 107, 101, 110, 49, 0, 6, 116, 111, 107, 101, 110, 51],
+  ],
+  [
+    "large connection IDs",
+    {
+      type: "connectUsers",
+      connectionIds: [12345, 67890],
+      connectionTokens: [null, null],
+    },
+    getNetworkedDOMProtocolSubProtocol_v0_2SubversionOrThrow(
+      networkedDOMProtocolSubProtocol_v0_2_1,
+    ),
+    [14, 2, 185, 96, 178, 146, 4, 0, 0],
+  ],
+];
+
+describe("encode/decode connectUsers", () => {
+  test.each(cases)("%p", (name, message, protocolSubversion, expectedResult) => {
+    const writer = new BufferWriter(64);
+    encodeConnectUsers(message, writer, protocolSubversion);
+    const encoded = writer.getBuffer();
+    expect(Array.from(encoded)).toEqual(expectedResult);
+    const reader = new BufferReader(encoded);
+    expect(reader.readUInt8()).toEqual(ConnectUsersMessageType);
+    const decoded = decodeConnectUsers(reader, protocolSubversion);
+    expect(decoded).toEqual(message);
+  });
+});

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/connectUsers.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/connectUsers.ts
@@ -1,15 +1,20 @@
 import { BufferReader } from "../../BufferReader";
 import { BufferWriter } from "../../BufferWriter";
+import { networkedDOMProtocolSubProtocol_v0_2_SubversionNumber } from "../../constants";
+import { protocolSubversionHasConnectionTokens } from "../../featureDetection";
 import { ConnectUsersMessageType } from "../../messageTypes";
 
 export type NetworkedDOMV02ConnectUsersMessage = {
   type: "connectUsers";
   connectionIds: Array<number>;
+  // Enabled in networked-dom-v0.2.1 and above
+  connectionTokens: Array<string | null>; // Optional tokens for each connection ID. On decoding empty string will be interpreted as null
 };
 
 export function encodeConnectUsers(
   connectUsersMessage: NetworkedDOMV02ConnectUsersMessage,
   writer: BufferWriter,
+  protocolSubversion: networkedDOMProtocolSubProtocol_v0_2_SubversionNumber,
 ) {
   const connectionIdsLength = connectUsersMessage.connectionIds.length;
   writer.writeUint8(ConnectUsersMessageType);
@@ -17,17 +22,52 @@ export function encodeConnectUsers(
   for (let i = 0; i < connectionIdsLength; i++) {
     writer.writeUVarint(connectUsersMessage.connectionIds[i]);
   }
+  if (protocolSubversionHasConnectionTokens(protocolSubversion)) {
+    if (connectUsersMessage.connectionTokens.length !== connectionIdsLength) {
+      throw new Error(
+        `connectionTokens length (${connectUsersMessage.connectionTokens.length}) does not match connectionIds length (${connectionIdsLength})`,
+      );
+    }
+    for (let i = 0; i < connectionIdsLength; i++) {
+      const token = connectUsersMessage.connectionTokens[i];
+      if (token === null || token === undefined) {
+        writer.writeUVarint(0); // Length 0 means no token
+      } else {
+        writer.writeLengthPrefixedString(token);
+      }
+    }
+  }
 }
 
 // Assumes that the first byte has already been read (the message type)
-export function decodeConnectUsers(buffer: BufferReader): NetworkedDOMV02ConnectUsersMessage {
+export function decodeConnectUsers(
+  buffer: BufferReader,
+  protocolSubversion: networkedDOMProtocolSubProtocol_v0_2_SubversionNumber,
+): NetworkedDOMV02ConnectUsersMessage {
   const connectionIds: number[] = [];
   const connectionIdsLength = buffer.readUVarint();
   for (let i = 0; i < connectionIdsLength; i++) {
     connectionIds.push(buffer.readUVarint());
   }
+  const connectionTokens: Array<string | null> = [];
+  if (protocolSubversionHasConnectionTokens(protocolSubversion)) {
+    for (let i = 0; i < connectionIdsLength; i++) {
+      const token = buffer.readUVarintPrefixedString();
+      if (token === "") {
+        connectionTokens.push(null);
+      } else {
+        connectionTokens.push(token);
+      }
+    }
+  } else {
+    // This client doesn't support connection tokens, so fill with nulls for the server to interpret as "no token"
+    for (let i = 0; i < connectionIdsLength; i++) {
+      connectionTokens.push(null);
+    }
+  }
   return {
     type: "connectUsers",
     connectionIds,
+    connectionTokens,
   };
 }

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/disconnectUsers.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/disconnectUsers.test.ts
@@ -1,0 +1,56 @@
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { DisconnectUsersMessageType } from "../../messageTypes";
+import {
+  decodeDisconnectUsers,
+  encodeDisconnectUsers,
+  NetworkedDOMV02DisconnectUsersMessage,
+} from "./disconnectUsers";
+
+const cases: Array<[string, NetworkedDOMV02DisconnectUsersMessage, Array<number>]> = [
+  [
+    "empty connection list",
+    {
+      type: "disconnectUsers",
+      connectionIds: [],
+    },
+    [15, 0],
+  ],
+  [
+    "single connection",
+    {
+      type: "disconnectUsers",
+      connectionIds: [123],
+    },
+    [15, 1, 123],
+  ],
+  [
+    "multiple connections",
+    {
+      type: "disconnectUsers",
+      connectionIds: [123, 456, 789],
+    },
+    [15, 3, 123, 200, 3, 149, 6],
+  ],
+  [
+    "large connection IDs",
+    {
+      type: "disconnectUsers",
+      connectionIds: [12345, 67890, 1234567890],
+    },
+    [15, 3, 185, 96, 178, 146, 4, 210, 133, 216, 204, 4],
+  ],
+];
+
+describe("encode/decode disconnectUsers", () => {
+  test.each(cases)("%p", (name, message, expectedResult) => {
+    const writer = new BufferWriter(64);
+    encodeDisconnectUsers(message, writer);
+    const encoded = writer.getBuffer();
+    expect(Array.from(encoded)).toEqual(expectedResult);
+    const reader = new BufferReader(encoded);
+    expect(reader.readUInt8()).toEqual(DisconnectUsersMessageType);
+    const decoded = decodeDisconnectUsers(reader);
+    expect(decoded).toEqual(message);
+  });
+});

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/event.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/event.test.ts
@@ -1,0 +1,95 @@
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { EventMessageType } from "../../messageTypes";
+import { decodeEvent, encodeEvent, NetworkedDOMV02RemoteEvent } from "./event";
+
+const cases: Array<[string, NetworkedDOMV02RemoteEvent, Array<number>]> = [
+  [
+    "simple click event",
+    {
+      type: "event",
+      connectionId: 123,
+      nodeId: 456,
+      name: "click",
+      bubbles: true,
+      params: {},
+    },
+    [16, 200, 3, 123, 5, 99, 108, 105, 99, 107, 1, 2, 123, 125],
+  ],
+  [
+    "event with no bubbles",
+    {
+      type: "event",
+      connectionId: 1,
+      nodeId: 2,
+      name: "hover",
+      bubbles: false,
+      params: { x: 100, y: 200 },
+    },
+    [
+      16, 2, 1, 5, 104, 111, 118, 101, 114, 0, 17, 123, 34, 120, 34, 58, 49, 48, 48, 44, 34, 121,
+      34, 58, 50, 48, 48, 125,
+    ],
+  ],
+  [
+    "event with complex params",
+    {
+      type: "event",
+      connectionId: 42,
+      nodeId: 100,
+      name: "custom",
+      bubbles: true,
+      params: {
+        data: "test",
+        numbers: [1, 2, 3],
+        nested: { key: "value" },
+      },
+    },
+    [
+      16, 100, 42, 6, 99, 117, 115, 116, 111, 109, 1, 58, 123, 34, 100, 97, 116, 97, 34, 58, 34,
+      116, 101, 115, 116, 34, 44, 34, 110, 117, 109, 98, 101, 114, 115, 34, 58, 91, 49, 44, 50, 44,
+      51, 93, 44, 34, 110, 101, 115, 116, 101, 100, 34, 58, 123, 34, 107, 101, 121, 34, 58, 34, 118,
+      97, 108, 117, 101, 34, 125, 125,
+    ],
+  ],
+  [
+    "event with null params",
+    {
+      type: "event",
+      connectionId: 1,
+      nodeId: 1,
+      name: "test",
+      bubbles: false,
+      params: null,
+    },
+    [16, 1, 1, 4, 116, 101, 115, 116, 0, 4, 110, 117, 108, 108],
+  ],
+  [
+    "large connection and node IDs",
+    {
+      type: "event",
+      connectionId: 12345,
+      nodeId: 67890,
+      name: "bigEvent",
+      bubbles: true,
+      params: { big: true },
+    },
+    [
+      16, 178, 146, 4, 185, 96, 8, 98, 105, 103, 69, 118, 101, 110, 116, 1, 12, 123, 34, 98, 105,
+      103, 34, 58, 116, 114, 117, 101, 125,
+    ],
+  ],
+];
+
+describe("encode/decode event", () => {
+  test.each(cases)("%p", (name, message, expectedResult) => {
+    const writer = new BufferWriter(128);
+    encodeEvent(message, writer);
+    const encoded = writer.getBuffer();
+    expect(Array.from(encoded)).toEqual(expectedResult);
+    const reader = new BufferReader(encoded);
+    expect(reader.readUInt8()).toEqual(EventMessageType);
+    const decoded = decodeEvent(reader);
+    expect(decoded).toEqual(message);
+  });
+});

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/pong.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-client/pong.test.ts
@@ -1,0 +1,52 @@
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { PongMessageType } from "../../messageTypes";
+import { decodePong, encodePong, NetworkedDOMV02PongMessage } from "./pong";
+
+const cases: Array<[string, NetworkedDOMV02PongMessage, Array<number>]> = [
+  [
+    "simple pong",
+    {
+      type: "pong",
+      pong: 123,
+    },
+    [17, 123],
+  ],
+  [
+    "pong with large value",
+    {
+      type: "pong",
+      pong: 1234567890,
+    },
+    [17, 210, 133, 216, 204, 4],
+  ],
+  [
+    "pong with zero value",
+    {
+      type: "pong",
+      pong: 0,
+    },
+    [17, 0],
+  ],
+  [
+    "pong with max safe integer",
+    {
+      type: "pong",
+      pong: 9007199254740991, // Number.MAX_SAFE_INTEGER
+    },
+    [17, 255, 255, 255, 255, 255, 255, 255, 15],
+  ],
+];
+
+describe("encode/decode pong", () => {
+  test.each(cases)("%p", (name, message, expectedResult) => {
+    const writer = new BufferWriter(16);
+    encodePong(message, writer);
+    const encoded = writer.getBuffer();
+    expect(Array.from(encoded)).toEqual(expectedResult);
+    const reader = new BufferReader(encoded);
+    expect(reader.readUInt8()).toEqual(PongMessageType);
+    const decoded = decodePong(reader);
+    expect(decoded).toEqual(message);
+  });
+});

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/attributesChanged.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/attributesChanged.test.ts
@@ -1,11 +1,11 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { AttributesChangedMessageType } from "../../messageTypes";
 import {
   decodeAttributesChanged,
   encodeAttributesChanged,
   NetworkedDOMV02AttributesChangedDiff,
-} from "../../src/networked-dom-v0.2/messages/from-server/attributesChanged";
-import { AttributesChangedMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+} from "./attributesChanged";
 
 const cases: Array<[string, NetworkedDOMV02AttributesChangedDiff, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/batchEnd.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/batchEnd.test.ts
@@ -1,0 +1,21 @@
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { BatchEndMessageType } from "../../messageTypes";
+import { batchEndMessage, encodeBatchEnd, NetworkedDOMV02BatchEndMessage } from "./batchEnd";
+
+const cases: Array<[string, NetworkedDOMV02BatchEndMessage, Array<number>]> = [
+  ["batch end message", batchEndMessage, [10]],
+];
+
+describe("encode/decode batchEnd", () => {
+  test.each(cases)("%p", (name, message, expectedResult) => {
+    const writer = new BufferWriter(16);
+    encodeBatchEnd(writer);
+    const encoded = writer.getBuffer();
+    expect(Array.from(encoded)).toEqual(expectedResult);
+    const reader = new BufferReader(encoded);
+    expect(reader.readUInt8()).toEqual(BatchEndMessageType);
+    // No decode function needed since batchEnd has no data beyond the message type
+    expect(message).toEqual(batchEndMessage);
+  });
+});

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/batchStart.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/batchStart.test.ts
@@ -1,0 +1,25 @@
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { BatchStartMessageType } from "../../messageTypes";
+import {
+  batchStartMessage,
+  encodeBatchStart,
+  NetworkedDOMV02BatchStartMessage,
+} from "./batchStart";
+
+const cases: Array<[string, NetworkedDOMV02BatchStartMessage, Array<number>]> = [
+  ["batch start message", batchStartMessage, [2]],
+];
+
+describe("encode/decode batchStart", () => {
+  test.each(cases)("%p", (name, message, expectedResult) => {
+    const writer = new BufferWriter(16);
+    encodeBatchStart(writer);
+    const encoded = writer.getBuffer();
+    expect(Array.from(encoded)).toEqual(expectedResult);
+    const reader = new BufferReader(encoded);
+    expect(reader.readUInt8()).toEqual(BatchStartMessageType);
+    // No decode function needed since batchStart has no data beyond the message type
+    expect(message).toEqual(batchStartMessage);
+  });
+});

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/changeHiddenFrom.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/changeHiddenFrom.test.ts
@@ -1,11 +1,11 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { ChangeHiddenFromMessageType } from "../../messageTypes";
 import {
   decodeChangeHiddenFrom,
   encodeChangeHiddenFrom,
   NetworkedDOMV02ChangeHiddenFromDiff,
-} from "../../src/networked-dom-v0.2/messages/from-server/changeHiddenFrom";
-import { ChangeHiddenFromMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+} from "./changeHiddenFrom";
 
 const cases: Array<[string, NetworkedDOMV02ChangeHiddenFromDiff, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/changeVisibleTo.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/changeVisibleTo.test.ts
@@ -1,11 +1,11 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { ChangeVisibleToMessageType } from "../../messageTypes";
 import {
   decodeChangeVisibleTo,
   encodeChangeVisibleTo,
   NetworkedDOMV02ChangeVisibleToDiff,
-} from "../../src/networked-dom-v0.2/messages/from-server/changeVisibleTo";
-import { ChangeVisibleToMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+} from "./changeVisibleTo";
 
 const cases: Array<[string, NetworkedDOMV02ChangeVisibleToDiff, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/childrenAdded.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/childrenAdded.test.ts
@@ -1,11 +1,11 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { ChildrenAddedMessageType } from "../../messageTypes";
 import {
   decodeChildrenAdded,
   encodeChildrenAdded,
   NetworkedDOMV02ChildrenAddedDiff,
-} from "../../src/networked-dom-v0.2/messages/from-server/childrenAdded";
-import { ChildrenAddedMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+} from "./childrenAdded";
 
 const cases: Array<[string, NetworkedDOMV02ChildrenAddedDiff, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/childrenRemoved.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/childrenRemoved.test.ts
@@ -1,11 +1,11 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { ChildrenRemovedMessageType } from "../../messageTypes";
 import {
   decodeChildrenRemoved,
   encodeChildrenRemoved,
   NetworkedDOMV02ChildrenRemovedDiff,
-} from "../../src/networked-dom-v0.2/messages/from-server/childrenRemoved";
-import { ChildrenRemovedMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+} from "./childrenRemoved";
 
 const cases: Array<[string, NetworkedDOMV02ChildrenRemovedDiff, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/documentTime.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/documentTime.test.ts
@@ -1,11 +1,11 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { DocumentTimeMessageType } from "../../messageTypes";
 import {
   decodeDocumentTime,
   encodeDocumentTime,
   NetworkedDOMV02DocumentTimeMessage,
-} from "../../src/networked-dom-v0.2/messages/from-server/documentTime";
-import { DocumentTimeMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+} from "./documentTime";
 
 const cases: Array<[string, NetworkedDOMV02DocumentTimeMessage, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/error.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/error.test.ts
@@ -1,8 +1,8 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
-import { decodeError, encodeError } from "../../src/networked-dom-v0.2/messages/from-server/error";
-import { NetworkedDOMV02ErrorMessage } from "../../src/networked-dom-v0.2/messages/from-server/error";
-import { ErrorMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { ErrorMessageType } from "../../messageTypes";
+import { decodeError, encodeError } from "./error";
+import { NetworkedDOMV02ErrorMessage } from "./error";
 
 const cases: Array<[string, NetworkedDOMV02ErrorMessage, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/ping.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/ping.test.ts
@@ -1,11 +1,7 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
-import {
-  decodePing,
-  encodePing,
-  NetworkedDOMV02PingMessage,
-} from "../../src/networked-dom-v0.2/messages/from-server/ping";
-import { PingMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { PingMessageType } from "../../messageTypes";
+import { decodePing, encodePing, NetworkedDOMV02PingMessage } from "./ping";
 
 const cases: Array<[string, NetworkedDOMV02PingMessage, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/snapshot.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/snapshot.test.ts
@@ -1,11 +1,7 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
-import {
-  decodeSnapshot,
-  encodeSnapshot,
-  NetworkedDOMV02SnapshotMessage,
-} from "../../src/networked-dom-v0.2/messages/from-server/snapshot";
-import { SnapshotMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { SnapshotMessageType } from "../../messageTypes";
+import { decodeSnapshot, encodeSnapshot, NetworkedDOMV02SnapshotMessage } from "./snapshot";
 
 const cases: Array<[string, NetworkedDOMV02SnapshotMessage, Array<number>]> = [
   [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/textChanged.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/textChanged.test.ts
@@ -1,0 +1,63 @@
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { TextChangedMessageType } from "../../messageTypes";
+import {
+  decodeTextChanged,
+  encodeTextChanged,
+  NetworkedDOMV02TextChangedDiff,
+} from "./textChanged";
+
+const cases: Array<[string, NetworkedDOMV02TextChangedDiff, Array<number>]> = [
+  [
+    "empty text",
+    {
+      type: "textChanged",
+      nodeId: 123,
+      text: "",
+    },
+    [9, 123, 0],
+  ],
+  [
+    "simple text",
+    {
+      type: "textChanged",
+      nodeId: 1,
+      text: "Hello World",
+    },
+    [9, 1, 11, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100],
+  ],
+  [
+    "large node id and unicode text",
+    {
+      type: "textChanged",
+      nodeId: 12345,
+      text: "Hello 🌍",
+    },
+    [9, 185, 96, 10, 72, 101, 108, 108, 111, 32, 240, 159, 140, 141],
+  ],
+  [
+    "multiline text",
+    {
+      type: "textChanged",
+      nodeId: 42,
+      text: "Line 1\nLine 2\nLine 3",
+    },
+    [
+      9, 42, 20, 76, 105, 110, 101, 32, 49, 10, 76, 105, 110, 101, 32, 50, 10, 76, 105, 110, 101,
+      32, 51,
+    ],
+  ],
+];
+
+describe("encode/decode textChanged", () => {
+  test.each(cases)("%p", (name, message, expectedResult) => {
+    const writer = new BufferWriter(16);
+    encodeTextChanged(message, writer);
+    const encoded = writer.getBuffer();
+    expect(Array.from(encoded)).toEqual(expectedResult);
+    const reader = new BufferReader(encoded);
+    expect(reader.readUInt8()).toEqual(TextChangedMessageType);
+    const decoded = decodeTextChanged(reader);
+    expect(decoded).toEqual(message);
+  });
+});

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/warning.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/messages/from-server/warning.test.ts
@@ -1,0 +1,54 @@
+import { BufferReader } from "../../BufferReader";
+import { BufferWriter } from "../../BufferWriter";
+import { WarningMessageType } from "../../messageTypes";
+import { decodeWarning, encodeWarning, NetworkedDOMV02WarningMessage } from "./warning";
+
+const cases: Array<[string, NetworkedDOMV02WarningMessage, Array<number>]> = [
+  [
+    "empty warning",
+    {
+      type: "warning",
+      message: "",
+    },
+    [12, 0],
+  ],
+  [
+    "simple warning",
+    {
+      type: "warning",
+      message: "This is a warning",
+    },
+    [12, 17, 84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 119, 97, 114, 110, 105, 110, 103],
+  ],
+  [
+    "long warning message",
+    {
+      type: "warning",
+      message:
+        "This is a very long warning message that exceeds the typical short message length and should test the uvarint encoding for longer strings properly",
+    },
+    [
+      12, 146, 1, 84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 118, 101, 114, 121, 32, 108, 111,
+      110, 103, 32, 119, 97, 114, 110, 105, 110, 103, 32, 109, 101, 115, 115, 97, 103, 101, 32, 116,
+      104, 97, 116, 32, 101, 120, 99, 101, 101, 100, 115, 32, 116, 104, 101, 32, 116, 121, 112, 105,
+      99, 97, 108, 32, 115, 104, 111, 114, 116, 32, 109, 101, 115, 115, 97, 103, 101, 32, 108, 101,
+      110, 103, 116, 104, 32, 97, 110, 100, 32, 115, 104, 111, 117, 108, 100, 32, 116, 101, 115,
+      116, 32, 116, 104, 101, 32, 117, 118, 97, 114, 105, 110, 116, 32, 101, 110, 99, 111, 100, 105,
+      110, 103, 32, 102, 111, 114, 32, 108, 111, 110, 103, 101, 114, 32, 115, 116, 114, 105, 110,
+      103, 115, 32, 112, 114, 111, 112, 101, 114, 108, 121,
+    ],
+  ],
+];
+
+describe("encode/decode warning", () => {
+  test.each(cases)("%p", (name, message, expectedResult) => {
+    const writer = new BufferWriter(16);
+    encodeWarning(message, writer);
+    const encoded = writer.getBuffer();
+    expect(Array.from(encoded)).toEqual(expectedResult);
+    const reader = new BufferReader(encoded);
+    expect(reader.readUInt8()).toEqual(WarningMessageType);
+    const decoded = decodeWarning(reader);
+    expect(decoded).toEqual(message);
+  });
+});

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/uvarint.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/uvarint.test.ts
@@ -1,5 +1,5 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
+import { BufferReader } from "./BufferReader";
+import { BufferWriter } from "./BufferWriter";
 
 describe("uvarint", () => {
   const uvarintCases: Array<[number, Array<number>]> = [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/varint.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/varint.test.ts
@@ -1,5 +1,5 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
+import { BufferReader } from "./BufferReader";
+import { BufferWriter } from "./BufferWriter";
 
 describe("varint", () => {
   const varintCases: Array<[number, Array<number>]> = [

--- a/packages/networked-dom-protocol/src/networked-dom-v0.2/warning.test.ts
+++ b/packages/networked-dom-protocol/src/networked-dom-v0.2/warning.test.ts
@@ -1,11 +1,8 @@
-import { BufferReader } from "../../src/networked-dom-v0.2/BufferReader";
-import { BufferWriter } from "../../src/networked-dom-v0.2/BufferWriter";
-import {
-  decodeWarning,
-  encodeWarning,
-} from "../../src/networked-dom-v0.2/messages/from-server/warning";
-import { NetworkedDOMV02WarningMessage } from "../../src/networked-dom-v0.2/messages/from-server/warning";
-import { WarningMessageType } from "../../src/networked-dom-v0.2/messageTypes";
+import { BufferReader } from "./BufferReader";
+import { BufferWriter } from "./BufferWriter";
+import { decodeWarning, encodeWarning } from "./messages/from-server/warning";
+import { NetworkedDOMV02WarningMessage } from "./messages/from-server/warning";
+import { WarningMessageType } from "./messageTypes";
 
 const cases: Array<[string, NetworkedDOMV02WarningMessage, Array<number>]> = [
   [

--- a/packages/networked-dom-web-runner-broadcast/src/NetworkedDOMBroadcastRunner.ts
+++ b/packages/networked-dom-web-runner-broadcast/src/NetworkedDOMBroadcastRunner.ts
@@ -53,7 +53,7 @@ export class NetworkedDOMBroadcastRunner {
     }
     const toDOMMessage: ToObservableDOMInstanceMessage = message.message;
     if (toDOMMessage.type === "addConnectedUserId") {
-      this.currentDOM.addConnectedUserId(toDOMMessage.connectionId);
+      this.currentDOM.addConnectedUserId(toDOMMessage.connectionId, toDOMMessage.connectionToken);
     } else if (toDOMMessage.type === "removeConnectedUserId") {
       this.currentDOM.removeConnectedUserId(toDOMMessage.connectionId);
     } else if (toDOMMessage.type === "dispatchRemoteEventFromConnectionId") {

--- a/packages/networked-dom-web-runner-broadcast/test/broadcast-end-to-end.test.ts
+++ b/packages/networked-dom-web-runner-broadcast/test/broadcast-end-to-end.test.ts
@@ -215,7 +215,7 @@ describe("broadcast", function () {
     });
 
     expect(broadcastRunnerOneHandlerSpy).toHaveBeenCalledWith({
-      message: { connectionId: 1, type: "addConnectedUserId" },
+      message: { connectionId: 1, connectionToken: null, type: "addConnectedUserId" },
       revisionId: 1,
       type: "instance",
     });
@@ -238,13 +238,13 @@ describe("broadcast", function () {
     });
 
     expect(broadcastRunnerOneHandlerSpy).toHaveBeenCalledWith({
-      message: { connectionId: 1, type: "addConnectedUserId" },
+      message: { connectionId: 1, connectionToken: null, type: "addConnectedUserId" },
       revisionId: 1,
       type: "instance",
     });
 
     expect(broadcastRunnerTwoHandlerSpy).toHaveBeenNthCalledWith(1, {
-      message: { connectionId: 1, type: "addConnectedUserId" },
+      message: { connectionId: 1, connectionToken: null, type: "addConnectedUserId" },
       revisionId: 1,
       type: "instance",
     });

--- a/packages/networked-dom-web-runner/networked-dom-web-runner-iframe/src/IframeWebRunner.ts
+++ b/packages/networked-dom-web-runner/networked-dom-web-runner-iframe/src/IframeWebRunner.ts
@@ -44,7 +44,7 @@ export function setupIframeWebRunner(argsString: string) {
         observableDOM.dispatchRemoteEventFromConnectionId(parsed.connectionId, parsed.event);
         break;
       case ADD_CONNECTED_USER_ID_MESSAGE_TYPE:
-        observableDOM.addConnectedUserId(parsed.connectionId);
+        observableDOM.addConnectedUserId(parsed.connectionId, parsed.connectionToken ?? null);
         break;
       case REMOVE_CONNECTED_USER_ID_MESSAGE_TYPE:
         observableDOM.removeConnectedUserId(parsed.connectionId);

--- a/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
+++ b/packages/networked-dom-web/src/NetworkedDOMWebsocket.ts
@@ -1,6 +1,7 @@
 import {
+  isNetworkedDOMProtocolSubProtocol_v0_2,
   networkedDOMProtocolSubProtocol_v0_1,
-  networkedDOMProtocolSubProtocol_v0_2,
+  networkedDOMProtocolSubProtocol_v0_2_SubVersionsList,
 } from "@mml-io/networked-dom-protocol";
 
 import { NetworkedDOMWebsocketV01Adapter } from "./NetworkedDOMWebsocketV01Adapter";
@@ -41,6 +42,7 @@ export type NetworkedDOMWebsocketOptions = {
   tagPrefix?: string; // e.g. "m-" to restrict to only custom elements with a tag name starting with "m-"
   replacementTagPrefix?: string; // e.g. "x-" to replace non-prefixed tags with a new prefix (e.g. "div" -> "x-div")
   allowSVGElements?: boolean; // Whether to allow SVG namespace elements to be created. Default is false.
+  connectionToken?: string | null; // Optional token to send to the server for authentication/authorization
 };
 
 export type NetworkedDOMWebsocketAdapter = {
@@ -65,7 +67,7 @@ export class NetworkedDOMWebsocket {
 
   public static createWebSocket(url: string): WebSocket {
     return new WebSocket(url, [
-      networkedDOMProtocolSubProtocol_v0_2,
+      ...networkedDOMProtocolSubProtocol_v0_2_SubVersionsList,
       networkedDOMProtocolSubProtocol_v0_1,
     ]);
   }
@@ -103,7 +105,7 @@ export class NetworkedDOMWebsocket {
         clearTimeout(timeoutId);
 
         this.websocket = websocket;
-        const isV02 = websocket.protocol === networkedDOMProtocolSubProtocol_v0_2;
+        const isV02 = isNetworkedDOMProtocolSubProtocol_v0_2(websocket.protocol);
         let websocketAdapter: NetworkedDOMWebsocketAdapter;
         if (isV02) {
           websocketAdapter = new NetworkedDOMWebsocketV02Adapter(

--- a/packages/observable-dom-common/src/ObservableDOMInterface.ts
+++ b/packages/observable-dom-common/src/ObservableDOMInterface.ts
@@ -33,7 +33,7 @@ export type StaticVirtualDOMMutationIdsRecord =
     };
 
 export type ObservableDOMInterface = {
-  addConnectedUserId(connectionId: number): void;
+  addConnectedUserId(connectionId: number, connectionToken: string | null): void;
   removeConnectedUserId(connectionId: number): void;
   dispatchRemoteEventFromConnectionId(
     connectionId: number,

--- a/packages/observable-dom-common/src/messages.ts
+++ b/packages/observable-dom-common/src/messages.ts
@@ -13,6 +13,7 @@ export const DOM_MESSAGE_TYPE = "dom";
 export type AddConnectedUserIdMessage = {
   type: typeof ADD_CONNECTED_USER_ID_MESSAGE_TYPE;
   connectionId: number;
+  connectionToken: string | null;
 };
 
 export type RemoveConnectedUserIdMessage = {
@@ -43,7 +44,7 @@ export function applyMessageToObservableDOMInstance(
   instance: ObservableDOMInterface,
 ) {
   if (message.type === ADD_CONNECTED_USER_ID_MESSAGE_TYPE) {
-    instance.addConnectedUserId(message.connectionId);
+    instance.addConnectedUserId(message.connectionId, message.connectionToken);
   } else if (message.type === REMOVE_CONNECTED_USER_ID_MESSAGE_TYPE) {
     instance.removeConnectedUserId(message.connectionId);
   } else if (message.type === DISPATCH_REMOTE_EVENT_FROM_CONNECTION_ID_MESSAGE_TYPE) {
@@ -58,10 +59,11 @@ export function observableDOMInterfaceToMessageSender(
   dispose: () => void,
 ) {
   const remoteObservableDOM: ObservableDOMInterface = {
-    addConnectedUserId(connectionId: number): void {
+    addConnectedUserId(connectionId: number, connectionToken: string | null): void {
       sender({
         type: ADD_CONNECTED_USER_ID_MESSAGE_TYPE,
         connectionId,
+        connectionToken,
       });
     },
     dispatchRemoteEventFromConnectionId(

--- a/packages/observable-dom/src/ObservableDOM.ts
+++ b/packages/observable-dom/src/ObservableDOM.ts
@@ -136,10 +136,10 @@ export class ObservableDOM implements ObservableDOMInterface {
     );
   }
 
-  public addConnectedUserId(connectionId: number): void {
+  public addConnectedUserId(connectionId: number, connectionToken: string | null): void {
     this.domRunner.getWindow().dispatchEvent(
       new (this.domRunner.getWindow().CustomEvent)("connected", {
-        detail: { connectionId },
+        detail: { connectionId, connectionToken },
       }),
     );
   }

--- a/packages/schema/src/schema-src/events.d.ts
+++ b/packages/schema/src/schema-src/events.d.ts
@@ -7,6 +7,10 @@ export interface RemoteEvent extends Event {
      * The unique numeric id of the connection that sent the event.
      */
     readonly connectionId: number;
+    /**
+     * The optional token string that a user may have provided when connecting.
+     */
+    readonly connectionToken: string | null;
   };
 }
 


### PR DESCRIPTION
This PR:
* Adds a `networked-dom-v0.2.1` version of the NetworkedDOM protocol that:
  * Adds a `connectionTokens` list to the `connectUsers` message type
* Clients prefer `networked-dom-v0.2.1` over `networked-dom-v0.2` as a WebSocket subprotocol.
* Adds support for feature detection in clients and server message encoding/decoding to allow backwards compatibility.
* The `connectionToken` for a particular user that is provided at the point of connecting is in the `connected` event that the server receives for that user. `connectionToken` is `null` if not provided.

```
<script>
  window.addEventListener("connected", (event) => {
    console.log("CONNECTED_EVENT:" + JSON.stringify({
      connectionId: event.detail.connectionId,
      connectionToken: event.detail.connectionToken
    }));
  });
</script>
```

Relates to #58 

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
