### PR TITLE
feat: Refactor MMLNetworkSource loading

### DIFF
--- a/packages/mml-viewer/src/PlayCanvasModeInternal.ts
+++ b/packages/mml-viewer/src/PlayCanvasModeInternal.ts
@@ -161,6 +161,8 @@ export class PlayCanvasModeInternal {
       graphicsAdapter,
     );
 
+    fullScreenMMLScene.getLoadingProgressManager().setInitialLoad(true);
+
     this.loadedState = {
       mmlNetworkSource,
       graphicsAdapter,

--- a/packages/mml-viewer/src/TagsMode.ts
+++ b/packages/mml-viewer/src/TagsMode.ts
@@ -85,6 +85,9 @@ export class TagsMode implements GraphicsMode {
       mmlScene: fullScreenMMLScene,
       remoteDocumentWrapper: mmlNetworkSource.remoteDocumentWrapper,
     });
+
+    fullScreenMMLScene.getLoadingProgressManager().setInitialLoad(true);
+
     this.loadedState = {
       mmlNetworkSource,
       graphicsAdapter,

--- a/packages/mml-viewer/src/ThreeJSModeInternal.ts
+++ b/packages/mml-viewer/src/ThreeJSModeInternal.ts
@@ -164,6 +164,8 @@ export class ThreeJSModeInternal {
       graphicsAdapter,
     );
 
+    fullScreenMMLScene.getLoadingProgressManager().setInitialLoad(true);
+
     this.loadedState = {
       mmlNetworkSource,
       graphicsAdapter,

--- a/packages/mml-web/src/elements/RemoteDocument.ts
+++ b/packages/mml-web/src/elements/RemoteDocument.ts
@@ -3,9 +3,12 @@ import { GraphicsAdapter } from "../graphics";
 import { RemoteDocumentGraphics } from "../graphics";
 import { IMMLScene } from "../scene";
 import { MMLDocumentTimeManager } from "../time";
-import { consumeEventEventName, MElement } from "./MElement";
+import { consumeEventEventName } from "./MElement";
+import { TransformableElement } from "./TransformableElement";
 
-export class RemoteDocument<G extends GraphicsAdapter = GraphicsAdapter> extends MElement<G> {
+export class RemoteDocument<
+  G extends GraphicsAdapter = GraphicsAdapter,
+> extends TransformableElement<G> {
   static tagName = "m-remote-document";
 
   private scene: IMMLScene<G> | null = null;

--- a/packages/mml-web/src/network/MMLNetworkSource.ts
+++ b/packages/mml-web/src/network/MMLNetworkSource.ts
@@ -1,5 +1,6 @@
 import { NetworkedDOMWebsocket, NetworkedDOMWebsocketStatus } from "@mml-io/networked-dom-web";
 
+import { createWrappedScene } from "../frame";
 import { LoadingProgressManager } from "../loading";
 import { fetchRemoteStaticMML, RemoteDocumentWrapper } from "../remote-document";
 import { IMMLScene } from "../scene";
@@ -33,17 +34,25 @@ export class MMLNetworkSource {
       overriddenHandler(element, event);
     };
 
+    const loadingProgressManager = new LoadingProgressManager();
+
+    const wrappedScene = createWrappedScene(this.options.mmlScene, loadingProgressManager);
+
     const src = this.options.url;
     this.remoteDocumentWrapper = new RemoteDocumentWrapper(
       src,
       this.options.windowTarget,
-      this.options.mmlScene,
+      wrappedScene,
       eventHandler,
     );
     this.options.targetForWrappers.append(this.remoteDocumentWrapper.remoteDocument);
-    let loadingProgressManager: LoadingProgressManager | null;
+
+    let sceneLoadingProgressManager: LoadingProgressManager | null = null;
     if (this.options.mmlScene.getLoadingProgressManager) {
-      loadingProgressManager = this.options.mmlScene.getLoadingProgressManager();
+      sceneLoadingProgressManager = this.options.mmlScene.getLoadingProgressManager();
+      loadingProgressManager.addProgressCallback(() => {
+        sceneLoadingProgressManager?.updateDocumentProgress(this);
+      });
     }
 
     const isWebsocket = src.startsWith("ws://") || src.startsWith("wss://");
@@ -56,8 +65,14 @@ export class MMLNetworkSource {
           this.remoteDocumentWrapper.setDocumentTime(time);
         },
         (status: NetworkedDOMWebsocketStatus) => {
-          if (status === NetworkedDOMWebsocketStatus.Connected) {
-            loadingProgressManager?.setInitialLoad(true);
+          if (status === NetworkedDOMWebsocketStatus.Reconnecting) {
+            this.remoteDocumentWrapper.remoteDocument.showError(true);
+            loadingProgressManager.setInitialLoad(new Error("Failed to connect"));
+          } else if (status === NetworkedDOMWebsocketStatus.Connected) {
+            this.remoteDocumentWrapper.remoteDocument.showError(false);
+            loadingProgressManager.setInitialLoad(true);
+          } else {
+            this.remoteDocumentWrapper.remoteDocument.showError(false);
           }
           this.options.statusUpdated(status);
         },
@@ -82,6 +97,8 @@ export class MMLNetworkSource {
         // Do nothing
       };
     }
+
+    sceneLoadingProgressManager?.addLoadingDocument(this, this.options.url, loadingProgressManager);
   }
 
   dispose() {
@@ -89,6 +106,7 @@ export class MMLNetworkSource {
       this.websocket.stop();
       this.websocket = null;
     }
+    this.options.mmlScene.getLoadingProgressManager?.()?.removeLoadingDocument(this);
     this.remoteDocumentWrapper.remoteDocument.remove();
   }
 }


### PR DESCRIPTION
This PR:
* Makes `RemoteDocument` transformable so that usages of `MMLNetworkSource` that need to be able to transform the position of the document can set attributes on that element.
* "Corrects" the loading state management of `MMLNetworkSource` to reflect that this class can be one of many MML documents in a scene and therefore it now has its own `LoadingProgressManager`.
  * This required cleaning up/adding logic to the MML standalone viewer classes that made the assumption that `MMLNetworkSource` would handle global loading progress.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Refactor

**Does your PR introduce a breaking change?** (check one)

- [x] Yes

If yes, please describe its impact and migration path for existing applications:

Any usage of `MMLNetworkSource` that assumed it would directly mutate the scene's `LoadingProgressManager` needs to be updated to reflect that the `MMLNetworkSource` now creates a sub `LoadingProgressManager` and is just a document in the scene's `LoadingProgressManager`.

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
