### PR TITLE
feat: resolveRelativeUrl function

### DIFF
--- a/packages/mml-web/src/frame/WebSocketFrameInstance.ts
+++ b/packages/mml-web/src/frame/WebSocketFrameInstance.ts
@@ -3,6 +3,7 @@ import { NetworkedDOMWebsocket, NetworkedDOMWebsocketStatus } from "@mml-io/netw
 import { consumeEventEventName, MElement } from "../elements";
 import { GraphicsAdapter } from "../graphics";
 import { LoadingProgressManager } from "../loading";
+import { MMLNetworkSource } from "../network";
 import { RemoteDocumentWrapper } from "../remote-document";
 import { IMMLScene } from "../scene";
 import { createWrappedScene } from "./CreateWrappedScene";
@@ -36,7 +37,7 @@ export class WebSocketFrameInstance<G extends GraphicsAdapter = GraphicsAdapter>
       scene.getLoadingProgressManager?.()?.updateDocumentProgress(this);
     });
 
-    const websocketAddress = this.srcToAddress(this.src);
+    const websocketAddress = MMLNetworkSource.resolveRelativeUrl(this.getDocumentHost(), this.src);
 
     scene
       .getLoadingProgressManager?.()
@@ -88,20 +89,6 @@ export class WebSocketFrameInstance<G extends GraphicsAdapter = GraphicsAdapter>
     overriddenHandler = (element: MElement<G>, event: CustomEvent) => {
       this.domWebsocket.handleEvent(element, event);
     };
-  }
-
-  private srcToAddress(src: string): string {
-    const insecurePrefix = "ws:///";
-    const securePrefix = "wss:///";
-    if (src.startsWith(insecurePrefix)) {
-      // Relative insecure websocket path
-      return `ws://${this.getDocumentHost()}/${src.substring(insecurePrefix.length)}`;
-    } else if (src.startsWith(securePrefix)) {
-      // Relative secure websocket path
-      return `wss://${this.getDocumentHost()}/${src.substring(securePrefix.length)}`;
-    } else {
-      return src;
-    }
   }
 
   private getDocumentHost(): string {

--- a/packages/mml-web/src/network/MMLNetworkSource.ts
+++ b/packages/mml-web/src/network/MMLNetworkSource.ts
@@ -106,6 +106,28 @@ export class MMLNetworkSource {
     sceneLoadingProgressManager?.addLoadingDocument(this, this.options.url, loadingProgressManager);
   }
 
+  /**
+   * Returns a URL relative to the given host if the src starts with "ws:///" or "wss:///".
+   * If the src does not start with either prefix, it is returned unchanged.
+   *
+   * @param {string} host - The host to use for constructing the potentially relative URL.
+   * @param {string} src - The URL, which may be relative (starting with "ws:///" or "wss:///") or absolute.
+   * @returns {string} The absolute URL (if it were previously relative ws:/// or wss:///).
+   */
+  public static resolveRelativeUrl(host: string, src: string): string {
+    const insecurePrefix = "ws:///";
+    const securePrefix = "wss:///";
+    if (src.startsWith(insecurePrefix)) {
+      // Relative insecure websocket path
+      return `ws://${host}/${src.substring(insecurePrefix.length)}`;
+    } else if (src.startsWith(securePrefix)) {
+      // Relative secure websocket path
+      return `wss://${host}/${src.substring(securePrefix.length)}`;
+    } else {
+      return src;
+    }
+  }
+
   dispose() {
     if (this.websocket) {
       this.websocket.stop();


### PR DESCRIPTION
Exposes the function `MMLNetworkSource.resolveRelativeUrl` which was previously a private function `srcToAddress` of `WebSocketFrameInstance`.

This allows usages of `MMLNetworkSource` which are agnostic to whether the url is relative, absolute, ws, or http to call this function to achieve the same behaviour as if they had used an `m-frame`.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
