### PR TITLE
fix: issue where visible-to would fail with multiple observers

### DIFF
--- a/integration-tests/networked-dom-integration-tests/test/networked-dom-nested-reload-text.test.ts
+++ b/integration-tests/networked-dom-integration-tests/test/networked-dom-nested-reload-text.test.ts
@@ -54,19 +54,19 @@ describe.each([{ version: 0.1 }, { version: 0.2 }])(
         new CustomEvent("click"),
       );
 
-      await client1.waitForAllClientMessages(isV01 ? 4 : 2);
+      await client1.waitForAllClientMessages(isV01 ? 4 : 6);
 
       // Reload the document without any changes - this causes a node remapping
       testCase.doc.load(testDocument);
 
-      await client1.waitForAllClientMessages(isV01 ? 7 : 5);
+      await client1.waitForAllClientMessages(isV01 ? 7 : 9);
 
       client1.networkedDOMWebsocket.handleEvent(
         client1.clientElement.querySelector("#add-level-2")!,
         new CustomEvent("click"),
       );
 
-      await client1.waitForAllClientMessages(isV01 ? 8 : 6);
+      await client1.waitForAllClientMessages(isV01 ? 8 : 10);
     });
   },
 );

--- a/integration-tests/networked-dom-integration-tests/test/networked-dom.test.ts
+++ b/integration-tests/networked-dom-integration-tests/test/networked-dom.test.ts
@@ -68,7 +68,7 @@ describe.each([{ version: 0.1 }, { version: 0.2 }])(
     </m-cube>
   </body>
 </html>`);
-      await client1.waitForAllClientMessages(isV01 ? 5 : 2);
+      await client1.waitForAllClientMessages(isV01 ? 5 : 7);
       expect(client1.getFormattedHTML()).toEqual(formatHTML(`<div>${expected}</div>`));
       expect(testCase.getFormattedAndFilteredHTML()).toEqual(expected);
     });
@@ -105,7 +105,7 @@ describe.each([{ version: 0.1 }, { version: 0.2 }])(
     </m-cube>
   </body>
 </html>`);
-      await client1.waitForAllClientMessages(isV01 ? 4 : 2);
+      await client1.waitForAllClientMessages(isV01 ? 4 : 6);
       expect(client1.getFormattedHTML()).toEqual(formatHTML(`<div>${expected}</div>`));
       expect(testCase.getFormattedAndFilteredHTML()).toEqual(expected);
     });
@@ -205,6 +205,580 @@ describe.each([{ version: 0.1 }, { version: 0.2 }])(
       <m-cube visible-to="2" color="green" x="2" id="c2">
       </m-cube>
     </m-cube>
+  </body>
+</html>`),
+      );
+    });
+
+    test("visible-to with dynamic child addition", async () => {
+      const testCase = new TestCaseNetworkedDOMDocument();
+      const client1 = testCase.createClient(isV01);
+      await client1.onConnectionOpened();
+      const client2 = testCase.createClient(isV01);
+      await client2.onConnectionOpened();
+
+      testCase.doc.load(`
+<m-cube color="red" z="2" id="c1">
+  <m-cube visible-to="1" color="green" x="2" id="c2">
+  </m-cube>
+</m-cube>
+
+<script>
+  const c1 = document.getElementById("c1");
+  const c2 = document.getElementById("c2");
+  c1.addEventListener("click", () => {
+    const newChild = document.createElement("m-cube");
+    newChild.setAttribute("color", "blue");
+    newChild.setAttribute("y", "1");
+    newChild.setAttribute("id", "c3");
+    c2.appendChild(newChild);
+  }, 1);
+</script>`);
+
+      await client1.waitForAllClientMessages(isV01 ? 1 : 1);
+      await client2.waitForAllClientMessages(isV01 ? 1 : 1);
+
+      // Initial state: client1 sees the visible-to="1" element, client2 doesn't
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube color="green" x="2" id="c2"></m-cube>
+    </m-cube>
+  </body>
+</html></div>`),
+      );
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+    </m-cube>
+  </body>
+</html></div>`),
+      );
+
+      // Trigger the addition of a child to the visible-to parent
+      client1.networkedDOMWebsocket.handleEvent(
+        client1.clientElement.querySelector("#c1")!,
+        new CustomEvent("click"),
+      );
+
+      await client1.waitForAllClientMessages(isV01 ? 2 : 2);
+      await client2.waitForAllClientMessages(isV01 ? 1 : 1);
+
+      // After adding child: client1 sees the new child in the visible-to parent, client2 still doesn't see anything
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube color="green" x="2" id="c2">
+        <m-cube color="blue" y="1" id="c3"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`),
+      );
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+    </m-cube>
+  </body>
+</html></div>`),
+      );
+
+      // Server's view should show the visible-to attribute and the new child
+      expect(testCase.getFormattedAndFilteredHTML()).toEqual(
+        formatHTML(`<html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube visible-to="1" color="green" x="2" id="c2">
+        <m-cube color="blue" y="1" id="c3"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html>`),
+      );
+    });
+
+    test("visible-to with cloned element using innerHTML", async () => {
+      const testCase = new TestCaseNetworkedDOMDocument();
+      const client1 = testCase.createClient(isV01);
+      await client1.onConnectionOpened();
+      const client2 = testCase.createClient(isV01);
+      await client2.onConnectionOpened();
+
+      testCase.doc.load(`
+<m-cube color="red" z="2" id="c1">
+  <m-cube hidden-from="999" color="blue" x="1" id="source">
+    <m-cube color="yellow" y="1" id="child1"></m-cube>
+    <m-cube color="purple" y="2" id="child2"></m-cube>
+  </m-cube>
+</m-cube>
+
+<script>
+  const c1 = document.getElementById("c1");
+  const source = document.getElementById("source");
+  c1.addEventListener("click", () => {
+    const cloned = document.createElement("m-cube");
+    cloned.innerHTML = source.innerHTML;
+    cloned.setAttribute("visible-to", "1");
+    cloned.setAttribute("color", "green");
+    cloned.setAttribute("x", "3");
+    cloned.setAttribute("id", "cloned1");
+    c1.appendChild(cloned);
+    
+    // Add the client's connection ID to the source element's hidden-from
+    const currentHiddenFrom = source.getAttribute("hidden-from") || "";
+    const newHiddenFrom = currentHiddenFrom ? currentHiddenFrom + ",1" : "1";
+    source.setAttribute("hidden-from", newHiddenFrom);
+  }, 1);
+  
+  // Add event listener for client 2's cloning operation
+  c1.addEventListener("dblclick", () => {
+    const cloned = document.createElement("m-cube");
+    cloned.innerHTML = source.innerHTML;
+    cloned.setAttribute("visible-to", "2");
+    cloned.setAttribute("color", "orange");
+    cloned.setAttribute("x", "5");
+    cloned.setAttribute("id", "cloned2");
+    c1.appendChild(cloned);
+    
+    // Add client 2's connection ID to the source element's hidden-from
+    const currentHiddenFrom = source.getAttribute("hidden-from") || "";
+    const newHiddenFrom = currentHiddenFrom.includes("2") ? currentHiddenFrom : currentHiddenFrom + ",2";
+    source.setAttribute("hidden-from", newHiddenFrom);
+  }, 1);
+</script>`);
+
+      await client1.waitForAllClientMessages(isV01 ? 1 : 1);
+      await client2.waitForAllClientMessages(isV01 ? 1 : 1);
+
+      // Initial state: both clients see the source element (hidden-from="999" doesn't affect either client)
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube color="blue" x="1" id="source">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`),
+      );
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube color="blue" x="1" id="source">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`),
+      );
+
+      // Trigger the cloning operation
+      client1.networkedDOMWebsocket.handleEvent(
+        client1.clientElement.querySelector("#c1")!,
+        new CustomEvent("click"),
+      );
+
+      await client1.waitForAllClientMessages(isV01 ? 3 : 5);
+      await client2.waitForAllClientMessages(isV01 ? 1 : 1);
+
+      // After cloning: client1 no longer sees the source element (hidden from 1) but sees the cloned element
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(
+          isV01
+            ? `<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube color="green" x="3" id="cloned1">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`
+            : `<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <x-hidden></x-hidden>
+      <m-cube color="green" x="3" id="cloned1">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`,
+        ),
+      );
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube color="blue" x="1" id="source">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`),
+      );
+
+      // Server's view should show both elements with their respective visibility attributes
+      expect(testCase.getFormattedAndFilteredHTML()).toEqual(
+        formatHTML(`<html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube hidden-from="999,1" color="blue" x="1" id="source">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+      <m-cube visible-to="1" color="green" x="3" id="cloned1">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html>`),
+      );
+
+      // Now trigger client 2's cloning operation
+      client2.networkedDOMWebsocket.handleEvent(
+        client2.clientElement.querySelector("#c1")!,
+        new CustomEvent("dblclick"),
+      );
+
+      await client1.waitForAllClientMessages(isV01 ? 3 : 5);
+      await client2.waitForAllClientMessages(isV01 ? 3 : 5);
+
+      // After client 2's cloning: client1 sees only their clone, client2 sees only their clone, source is hidden from both
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(
+          isV01
+            ? `<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube color="green" x="3" id="cloned1">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`
+            : `<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <x-hidden></x-hidden>
+      <m-cube color="green" x="3" id="cloned1">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`,
+        ),
+      );
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(
+          isV01
+            ? `<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube color="orange" x="5" id="cloned2">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`
+            : `<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <x-hidden></x-hidden>
+      <m-cube color="orange" x="5" id="cloned2">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html></div>`,
+        ),
+      );
+
+      // Final server view should show source hidden from both clients and both clones
+      expect(testCase.getFormattedAndFilteredHTML()).toEqual(
+        formatHTML(`<html>
+  <head>
+  </head>
+  <body>
+    <m-cube color="red" z="2" id="c1">
+      <m-cube hidden-from="999,1,2" color="blue" x="1" id="source">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+      <m-cube visible-to="1" color="green" x="3" id="cloned1">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+      <m-cube visible-to="2" color="orange" x="5" id="cloned2">
+        <m-cube color="yellow" y="1" id="child1"></m-cube>
+        <m-cube color="purple" y="2" id="child2"></m-cube>
+      </m-cube>
+    </m-cube>
+  </body>
+</html>`),
+      );
+    });
+
+    test("multiple visible-to element addition and removal", async () => {
+      const testCase = new TestCaseNetworkedDOMDocument();
+      const client1 = testCase.createClient(isV01);
+      await client1.onConnectionOpened();
+      const client2 = testCase.createClient(isV01);
+      await client2.onConnectionOpened();
+
+      testCase.doc.load(`<m-cube id="trigger"></m-cube>
+<script>
+  document.getElementById("trigger").addEventListener("click", (e) => {
+    const holder = document.createElement("m-sphere");
+    holder.setAttribute("visible-to", String(e.detail?.connectionId));
+    holder.setAttribute("id", "holder-" + e.detail?.connectionId);
+    document.body.appendChild(holder);
+    
+    // Add click listener to holder to create child
+    holder.addEventListener("click", (holderEvent) => {
+      const child = document.createElement("m-cylinder");
+      child.setAttribute("id", "child-" + e.detail?.connectionId);
+      holder.appendChild(child);
+      
+      // Add click listener to child to remove itself
+      child.addEventListener("click", (childEvent) => {
+        childEvent.stopPropagation();
+        childEvent.preventDefault();
+        child.remove();
+      });
+    });
+  });
+</script>`);
+
+      await client1.waitForAllClientMessages(isV01 ? 1 : 1);
+      await client2.waitForAllClientMessages(isV01 ? 1 : 1);
+
+      // Initial state: both clients see the trigger
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+  </body>
+</html></div>`),
+      );
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+  </body>
+</html></div>`),
+      );
+
+      // Client 1 clicks the trigger to create holder
+      client1.networkedDOMWebsocket.handleEvent(
+        client1.clientElement.querySelector("#trigger")!,
+        new CustomEvent("click"),
+      );
+
+      await client1.waitForAllClientMessages(isV01 ? 2 : 2);
+      await client2.waitForAllClientMessages(isV01 ? 1 : 1);
+
+      // After client 1's click: client1 should see the holder, client2 sees nothing new
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+    <m-sphere id="holder-1"></m-sphere>
+  </body>
+</html></div>`),
+      );
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+  </body>
+</html></div>`),
+      );
+
+      // Client 1 clicks the holder to create child
+      client1.networkedDOMWebsocket.handleEvent(
+        client1.clientElement.querySelector("#holder-1")!,
+        new CustomEvent("click"),
+      );
+
+      await client1.waitForAllClientMessages(isV01 ? 3 : 3);
+      await client2.waitForAllClientMessages(isV01 ? 1 : 1);
+
+      // After creating child: client1 should see holder with child
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+    <m-sphere id="holder-1">
+      <m-cylinder id="child-1"></m-cylinder>
+    </m-sphere>
+  </body>
+</html></div>`),
+      );
+
+      // Client 1 clicks the child to remove it
+      client1.networkedDOMWebsocket.handleEvent(
+        client1.clientElement.querySelector("#child-1")!,
+        new CustomEvent("click"),
+      );
+
+      await client1.waitForAllClientMessages(isV01 ? 4 : 4);
+      await client2.waitForAllClientMessages(isV01 ? 1 : 1);
+
+      // After removing child: client1 should see just the holder
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+    <m-sphere id="holder-1"></m-sphere>
+  </body>
+</html></div>`),
+      );
+
+      // Client 2 clicks the trigger to create their holder
+      client2.networkedDOMWebsocket.handleEvent(
+        client2.clientElement.querySelector("#trigger")!,
+        new CustomEvent("click"),
+      );
+
+      await client1.waitForAllClientMessages(isV01 ? 4 : 4);
+      await client2.waitForAllClientMessages(isV01 ? 2 : 2);
+
+      // After client 2's trigger click: client1 sees their holder, client2 sees their holder
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+    <m-sphere id="holder-2"></m-sphere>
+  </body>
+</html></div>`),
+      );
+
+      // Client 2 clicks their holder to create child
+      client2.networkedDOMWebsocket.handleEvent(
+        client2.clientElement.querySelector("#holder-2")!,
+        new CustomEvent("click"),
+      );
+
+      await client1.waitForAllClientMessages(isV01 ? 4 : 4);
+      await client2.waitForAllClientMessages(isV01 ? 3 : 3);
+
+      // After creating child: client2 should see holder with child
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+    <m-sphere id="holder-2">
+      <m-cylinder id="child-2"></m-cylinder>
+    </m-sphere>
+  </body>
+</html></div>`),
+      );
+
+      // Client 2 clicks their child to remove it - this should trigger the bug
+      client2.networkedDOMWebsocket.handleEvent(
+        client2.clientElement.querySelector("#child-2")!,
+        new CustomEvent("click"),
+      );
+
+      // Wait for messages after client 2's child removal - this should fail due to the bug
+      // The test expects these message counts but the bug will cause an error
+      await client1.waitForAllClientMessages(isV01 ? 4 : 4);
+      await client2.waitForAllClientMessages(isV01 ? 4 : 4);
+
+      // Expected final state (this won't be reached due to the bug)
+      expect(client1.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+    <m-sphere id="holder-1"></m-sphere>
+  </body>
+</html></div>`),
+      );
+      expect(client2.getFormattedHTML()).toEqual(
+        formatHTML(`<div><html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+    <m-sphere id="holder-2"></m-sphere>
+  </body>
+</html></div>`),
+      );
+
+      // Server should show both holders with their respective visible-to attributes
+      expect(testCase.getFormattedAndFilteredHTML()).toEqual(
+        formatHTML(`<html>
+  <head>
+  </head>
+  <body>
+    <m-cube id="trigger"></m-cube>
+    <m-sphere visible-to="1" id="holder-1"></m-sphere>
+    <m-sphere visible-to="2" id="holder-2"></m-sphere>
   </body>
 </html>`),
       );
@@ -541,7 +1115,7 @@ setTimeout(() => {
     </m-cube>
   </body>
 </html>`);
-      await client1.waitForAllClientMessages(isV01 ? 7 : 2);
+      await client1.waitForAllClientMessages(isV01 ? 7 : 9);
       expect(client1.getFormattedHTML()).toEqual(formatHTML(`<div>${expected}</div>`));
       expect(testCase.getFormattedAndFilteredHTML()).toEqual(expected);
     });
@@ -592,7 +1166,7 @@ setTimeout(() => {
       </m-group>
     </body>
   </html>`);
-      await client1.waitForAllClientMessages(isV01 ? 3 : 2);
+      await client1.waitForAllClientMessages(isV01 ? 3 : 5);
       expect(testCase.getFormattedAndFilteredHTML()).toEqual(expected);
       expect(client1.getFormattedHTML()).toEqual(formatHTML(`<div>${expected}</div>`));
     });

--- a/integration-tests/networked-dom-integration-tests/test/test-util.ts
+++ b/integration-tests/networked-dom-integration-tests/test/test-util.ts
@@ -1,17 +1,20 @@
-export function waitFor(condition: () => boolean, timeout = 1000) {
+export function waitFor(condition: () => true | string, timeout = 1000) {
+  const stack = new Error().stack;
   return new Promise<void>((resolve, reject) => {
     const interval = setInterval(() => {
-      if (condition()) {
+      const result = condition();
+      if (result === true) {
         clearInterval(interval);
         resolve();
       }
     }, 10);
     setTimeout(() => {
       clearInterval(interval);
-      if (condition()) {
+      const result = condition();
+      if (result === true) {
         resolve();
       } else {
-        reject(new Error("waitFor timeout"));
+        reject(new Error(`waitFor timeout. ${result}. Stack: ${stack}`));
       }
     }, timeout);
   });

--- a/packages/networked-dom-document/src/NetworkedDOM.ts
+++ b/packages/networked-dom-document/src/NetworkedDOM.ts
@@ -834,7 +834,7 @@ export class NetworkedDOM {
             true,
           );
         if (!canSeeParent) {
-          break;
+          continue;
         }
         let projectedPreviousNodeId: number | null = null;
         if (previousNode != null) {
@@ -924,7 +924,7 @@ export class NetworkedDOM {
             false,
           );
         if (!canSeeParent) {
-          break;
+          continue;
         }
         let projectedPreviousNodeId: number | null = null;
         if (previousNode != null) {


### PR DESCRIPTION
This PR fixes an issue where usage of the `visible-to` attribute could cause incorrect messages that were missing child elements to be sent to clients that would result in subsequent errors when/if those child elements were removed.

The root cause was an incorrect usage of `break` which should have been a `continue`. The usage of `break` meant that upon encountering the first client that shouldn't see the element the loop would exit rather than continue onto other clients that could potentially be sent the element.

To aid debugging this issue I improved the `waitForAllClientMessages` function which now correctly separates messages for counting when using the v0.2 protocol as previously multiple messages would be counted as one buffer because they were not decoded. This then resulted in multiple assertions being updated. I also improved the message and stack visibility when these assertions fail.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [ ] All tests are passing
