### PR TITLE
fix: cross-realm dispatchEvent when MML elements are in an iframe

### DIFF
--- a/packages/mml-web/src/elements/MElement.ts
+++ b/packages/mml-web/src/elements/MElement.ts
@@ -14,12 +14,56 @@ export const consumeEventEventName = "consume-event";
 export abstract class MElement<
   G extends GraphicsAdapter = GraphicsAdapter,
 > extends VirtualHTMLElement {
-  // This allows switching which document this HTMLElement subclass extends so that it can be placed into iframes
-  static overwriteSuperclass(newSuperclass: { new (): any; prototype: any }) {
+  /**
+   * Switches MElement's superclass to extend a target window's HTMLElement so that
+   * MML elements can be placed into iframes. Also stores a reference to the target
+   * window so that events can be created using its constructors (native dispatchEvent
+   * rejects cross-realm Event objects).
+   */
+  static overwriteSuperclass(
+    newSuperclass: { new (): HTMLElement; prototype: HTMLElement },
+    targetWindow: Window & typeof globalThis,
+  ) {
     Object.setPrototypeOf(MElement, newSuperclass);
     Object.setPrototypeOf(MElement.prototype, newSuperclass.prototype);
-    // Invalidate cached base dispatchEvent since the prototype chain has changed
+    // Invalidate cached dispatchEvent since the prototype chain has changed
     MElement.cachedBaseDispatchEvent = null;
+    MElement._isDOMMode = true;
+    MElement._domModeWindow = targetWindow;
+  }
+
+  /**
+   * Resets MElement back to virtual (non-DOM) mode by restoring VirtualHTMLElement as
+   * the superclass and clearing the DOM mode window reference.
+   * @internal
+   */
+  static resetToVirtualMode() {
+    Object.setPrototypeOf(MElement, VirtualHTMLElement);
+    Object.setPrototypeOf(MElement.prototype, VirtualHTMLElement.prototype);
+    MElement.cachedBaseDispatchEvent = null;
+    MElement._isDOMMode = false;
+    MElement._domModeWindow = null;
+  }
+
+  /**
+   * Whether MElement has been switched to DOM mode via overwriteSuperclass.
+   * Used instead of `instanceof Element` checks which fail across iframe boundaries
+   * (cross-realm instanceof returns false).
+   * @internal
+   */
+  private static _isDOMMode = false;
+  static get isDOMMode(): boolean {
+    return MElement._isDOMMode;
+  }
+
+  /**
+   * The target window for DOM mode. Used to create events in the correct realm
+   * so that native dispatchEvent accepts them.
+   * @internal
+   */
+  private static _domModeWindow: (Window & typeof globalThis) | null = null;
+  static get domModeWindow(): (Window & typeof globalThis) | null {
+    return MElement._domModeWindow;
   }
 
   /**
@@ -55,7 +99,11 @@ export abstract class MElement<
   }
 
   static getMElementFromObject(object: unknown): MElement<GraphicsAdapter> | null {
-    return (object as any)[MELEMENT_PROPERTY_NAME] || null;
+    return (
+      ((object as Record<string, unknown>)[MELEMENT_PROPERTY_NAME] as
+        | MElement<GraphicsAdapter>
+        | undefined) ?? null
+    );
   }
 
   public abstract isClickable(): boolean;
@@ -265,10 +313,10 @@ export abstract class MElement<
     element: MElement | VirtualHTMLElement,
     originalEvent: Event | VirtualCustomEvent,
   ): CustomEvent | VirtualCustomEvent {
-    // Use instanceof Element to reliably detect DOM mode. Element covers both
-    // HTMLElement and SVGElement (overlay portals may contain SVG content).
-    if (typeof Element !== "undefined" && element instanceof Element) {
-      return new CustomEvent(consumeEventEventName, {
+    // In DOM mode, create the CustomEvent using the target window's constructor so that
+    // it belongs to the same realm as native dispatchEvent (which rejects cross-realm events).
+    if (MElement.isDOMMode && MElement.domModeWindow) {
+      return new MElement.domModeWindow.CustomEvent(consumeEventEventName, {
         bubbles: false,
         detail: { element, originalEvent },
       });
@@ -282,15 +330,7 @@ export abstract class MElement<
   dispatchEvent(event: Event | VirtualCustomEvent): boolean {
     const remoteDocument = this.getInitiatedRemoteDocument();
     if (remoteDocument) {
-      // Only send the consume-event for the element on which dispatchEvent was originally called.
-      // In virtual mode, event bubbling explicitly calls parent.dispatchEvent(event) on each
-      // ancestor, which would create duplicate consume-events. In real DOM mode, the browser
-      // handles bubbling internally without calling dispatchEvent on parents. This flag ensures
-      // parity: only one consume-event per original dispatch, letting the server handle bubbling.
-      if (!(event as any).__mml_consumed) {
-        (event as any).__mml_consumed = true;
-        remoteDocument.dispatchEvent(MElement.createConsumeEvent(this, event));
-      }
+      remoteDocument.dispatchEvent(MElement.createConsumeEvent(this, event));
       return super.dispatchEvent(event);
     } else {
       const win = getGlobalWindow();

--- a/packages/mml-web/src/elements/register-custom-elements.ts
+++ b/packages/mml-web/src/elements/register-custom-elements.ts
@@ -6,7 +6,7 @@ export function registerCustomElementsToWindow(targetWindow: Window) {
   const targetHTMLElement = (targetWindow as unknown as { HTMLElement: typeof HTMLElement })[
     "HTMLElement"
   ];
-  MElement.overwriteSuperclass(targetHTMLElement);
+  MElement.overwriteSuperclass(targetHTMLElement, targetWindow as Window & typeof globalThis);
   // After overwriteSuperclass, MML element classes extend HTMLElement at runtime
   for (const Element of MML_ELEMENTS) {
     targetWindow.customElements.define(

--- a/packages/mml-web/src/virtual-dom/VirtualHTMLElement.ts
+++ b/packages/mml-web/src/virtual-dom/VirtualHTMLElement.ts
@@ -145,13 +145,13 @@ export class VirtualHTMLElement extends VirtualNode implements VirtualLifecycleC
     }
   }
 
-  dispatchEvent(event: VirtualEvent | Event): boolean {
+  /**
+   * Invokes only this node's listeners for the event, without bubbling.
+   * Returns whether propagation was stopped.
+   */
+  private _dispatchToLocalListeners(event: VirtualEvent | Event): boolean {
     const type: string = event.type;
     const isVirtual = event instanceof VirtualEvent;
-
-    if (isVirtual && (event as VirtualEvent).target === null) {
-      (event as VirtualEvent).target = this;
-    }
 
     const listeners = this._eventListeners.get(type);
     let immediateStopped = false;
@@ -182,14 +182,29 @@ export class VirtualHTMLElement extends VirtualNode implements VirtualLifecycleC
     } else if (event instanceof Event) {
       propagationStopped = event.cancelBubble;
     }
-    // Bubble
-    const bubbles = event.bubbles;
-    if (bubbles && !propagationStopped && this.parentNode) {
-      const parent = this.parentNode;
-      if (parent instanceof VirtualHTMLElement) {
-        parent.dispatchEvent(event);
+    return propagationStopped;
+  }
+
+  dispatchEvent(event: VirtualEvent | Event): boolean {
+    const isVirtual = event instanceof VirtualEvent;
+
+    if (isVirtual && (event as VirtualEvent).target === null) {
+      (event as VirtualEvent).target = this;
+    }
+
+    let propagationStopped = this._dispatchToLocalListeners(event);
+
+    // Bubble up the tree, calling listeners directly (not dispatchEvent) on ancestors.
+    // Stop at any non-VirtualHTMLElement node, matching the original recursive behavior.
+    if (event.bubbles && !propagationStopped) {
+      let ancestor = this.parentNode;
+      while (ancestor instanceof VirtualHTMLElement) {
+        propagationStopped = ancestor._dispatchToLocalListeners(event);
+        if (propagationStopped) break;
+        ancestor = ancestor.parentNode;
       }
     }
+
     if (isVirtual) {
       return !(event as VirtualEvent).isDefaultPrevented;
     }

--- a/packages/mml-web/test/MElement.test.ts
+++ b/packages/mml-web/test/MElement.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  consumeEventEventName,
+  Cube,
+  Group,
+  IMMLScene,
+  MElement,
+  registerCustomElementsToVirtualDocument,
+  registerCustomElementsToWindow,
+  RemoteDocument,
+  VirtualCustomEvent,
+  VirtualDocument,
+  VirtualHTMLElement,
+} from "../src";
+import { MML_ELEMENTS } from "../src/elements/mml-element-list";
+
+function createMockScene(): IMMLScene {
+  return {
+    hasGraphicsAdapter: () => false,
+    getGraphicsAdapter: () => {
+      throw new Error("No graphics adapter");
+    },
+    getUserPositionAndRotation: () => ({
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+    }),
+    prompt: () => {},
+    link: () => {},
+    getLoadingProgressManager: () => null,
+  } as IMMLScene;
+}
+
+function createDOMRemoteDocument(): RemoteDocument {
+  const remoteDoc = document.createElement("m-remote-document") as unknown as RemoteDocument;
+  remoteDoc.init(createMockScene(), "ws://test.local/doc");
+  document.body.appendChild(remoteDoc as unknown as Node);
+  return remoteDoc;
+}
+
+function createMElement<T>(tag: string): T {
+  return document.createElement(tag) as unknown as T;
+}
+
+function asNode(el: unknown): Node {
+  return el as unknown as Node;
+}
+
+function asHTMLElement(el: unknown): HTMLElement {
+  return el as unknown as HTMLElement;
+}
+
+function switchToDOMMode() {
+  const targetHTMLElement = (window as unknown as { HTMLElement: typeof HTMLElement }).HTMLElement;
+  MElement.overwriteSuperclass(targetHTMLElement, window);
+}
+
+registerCustomElementsToWindow(window);
+
+describe("createConsumeEvent", () => {
+  describe("DOM mode", () => {
+    test("returns a CustomEvent with correct type and detail", () => {
+      const cube = createMElement<Cube>("m-cube");
+      const originalEvent = new CustomEvent("click", { bubbles: true });
+      const consumeEvent = MElement.createConsumeEvent(cube, originalEvent);
+
+      expect(consumeEvent).toBeInstanceOf(CustomEvent);
+      expect(consumeEvent.type).toBe(consumeEventEventName);
+      expect(consumeEvent.bubbles).toBe(false);
+      expect((consumeEvent as CustomEvent).detail).toEqual({
+        element: cube,
+        originalEvent,
+      });
+    });
+
+    test("event is accepted by native HTMLElement.prototype.dispatchEvent", () => {
+      const target = document.createElement("div");
+      const cube = createMElement<Cube>("m-cube");
+      const consumeEvent = MElement.createConsumeEvent(
+        cube,
+        new CustomEvent("click", { bubbles: true }),
+      );
+
+      const listener = vi.fn();
+      target.addEventListener(consumeEventEventName, listener);
+      target.dispatchEvent(consumeEvent as CustomEvent);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].detail.element).toBe(cube);
+    });
+
+    test("uses domModeWindow's CustomEvent constructor", () => {
+      expect(MElement.domModeWindow).toBe(window);
+      const cube = createMElement<Cube>("m-cube");
+      const consumeEvent = MElement.createConsumeEvent(cube, new CustomEvent("test"));
+      expect(consumeEvent).toBeInstanceOf(window.CustomEvent);
+    });
+  });
+
+  describe("virtual mode", () => {
+    afterEach(() => {
+      switchToDOMMode();
+    });
+
+    test("returns a VirtualCustomEvent when not in DOM mode", () => {
+      MElement.resetToVirtualMode();
+
+      const mockElement = {} as VirtualHTMLElement;
+      const originalEvent = new VirtualCustomEvent("click", { bubbles: true });
+      const consumeEvent = MElement.createConsumeEvent(mockElement, originalEvent);
+
+      expect(consumeEvent).toBeInstanceOf(VirtualCustomEvent);
+      expect(consumeEvent.type).toBe(consumeEventEventName);
+      expect(consumeEvent.bubbles).toBe(false);
+      expect((consumeEvent as VirtualCustomEvent).detail).toEqual({
+        element: mockElement,
+        originalEvent,
+      });
+    });
+  });
+});
+
+describe("overwriteSuperclass", () => {
+  test("sets isDOMMode and domModeWindow", () => {
+    expect(MElement.isDOMMode).toBe(true);
+    expect(MElement.domModeWindow).toBe(window);
+  });
+
+  test("MElement prototype chain extends the target HTMLElement", () => {
+    const targetHTMLElement = (window as unknown as { HTMLElement: typeof HTMLElement })
+      .HTMLElement;
+    expect(Object.getPrototypeOf(MElement.prototype)).toBe(targetHTMLElement.prototype);
+    expect(Object.getPrototypeOf(MElement)).toBe(targetHTMLElement);
+  });
+
+  test("elements created after overwrite are instanceof HTMLElement", () => {
+    const cube = document.createElement("m-cube");
+    expect(cube).toBeInstanceOf(HTMLElement);
+  });
+
+  test("invalidates getBaseDispatchEvent cache", () => {
+    const first = MElement.getBaseDispatchEvent();
+    expect(typeof first).toBe("function");
+
+    switchToDOMMode();
+
+    const second = MElement.getBaseDispatchEvent();
+    expect(typeof second).toBe("function");
+  });
+});
+
+describe("resetToVirtualMode", () => {
+  afterEach(() => {
+    switchToDOMMode();
+  });
+
+  test("clears isDOMMode and domModeWindow", () => {
+    MElement.resetToVirtualMode();
+    expect(MElement.isDOMMode).toBe(false);
+    expect(MElement.domModeWindow).toBeNull();
+  });
+
+  test("restores VirtualHTMLElement as the superclass", () => {
+    MElement.resetToVirtualMode();
+    expect(Object.getPrototypeOf(MElement)).not.toBe(
+      (window as unknown as { HTMLElement: typeof HTMLElement }).HTMLElement,
+    );
+  });
+});
+
+describe("getBaseDispatchEvent", () => {
+  test("repeated calls return the same cached function", () => {
+    const first = MElement.getBaseDispatchEvent();
+    const second = MElement.getBaseDispatchEvent();
+    expect(first).toBe(second);
+  });
+
+  test("resolves to HTMLElement.prototype.dispatchEvent in DOM mode", () => {
+    const fn = MElement.getBaseDispatchEvent();
+    expect(fn).toBe(HTMLElement.prototype.dispatchEvent);
+  });
+});
+
+describe("consume-event dispatch flow (DOM mode)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("dispatching on an MElement sends consume-event to RemoteDocument", () => {
+    const remoteDoc = createDOMRemoteDocument();
+    const cube = createMElement<Cube>("m-cube");
+    asHTMLElement(remoteDoc).appendChild(asNode(cube));
+
+    const received: Array<{
+      element: MElement | VirtualHTMLElement;
+      originalEvent: Event | VirtualCustomEvent;
+    }> = [];
+    asHTMLElement(remoteDoc).addEventListener(consumeEventEventName, ((e: CustomEvent) =>
+      received.push(e.detail)) as EventListener);
+
+    const event = new CustomEvent("click", { bubbles: true });
+    cube.dispatchEvent(event);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].element).toBe(cube);
+    expect(received[0].originalEvent).toBe(event);
+  });
+
+  test("consume-event is only sent once per dispatch, not per ancestor", () => {
+    const remoteDoc = createDOMRemoteDocument();
+    const group = createMElement<Group>("m-group");
+    const cube = createMElement<Cube>("m-cube");
+    asHTMLElement(remoteDoc).appendChild(asNode(group));
+    asHTMLElement(group).appendChild(asNode(cube));
+
+    const received: Array<{ element: MElement | VirtualHTMLElement }> = [];
+    asHTMLElement(remoteDoc).addEventListener(consumeEventEventName, ((e: CustomEvent) =>
+      received.push(e.detail)) as EventListener);
+
+    cube.dispatchEvent(new CustomEvent("click", { bubbles: true }));
+
+    expect(received).toHaveLength(1);
+    expect(received[0].element).toBe(cube);
+  });
+
+  test("RemoteDocument stops consume-event propagation", () => {
+    const remoteDoc = createDOMRemoteDocument();
+    const cube = createMElement<Cube>("m-cube");
+    asHTMLElement(remoteDoc).appendChild(asNode(cube));
+
+    const bodyListener = vi.fn();
+    document.body.addEventListener(consumeEventEventName, bodyListener);
+
+    cube.dispatchEvent(new CustomEvent("click", { bubbles: true }));
+    expect(bodyListener).not.toHaveBeenCalled();
+
+    document.body.removeEventListener(consumeEventEventName, bodyListener);
+  });
+});
+
+describe("registerCustomElementsToWindow", () => {
+  test("all MML elements are registered as custom elements", () => {
+    for (const Element of MML_ELEMENTS) {
+      expect(window.customElements.get(Element.tagName)).toBeDefined();
+    }
+  });
+});
+
+describe("registerCustomElementsToVirtualDocument", () => {
+  afterEach(() => {
+    switchToDOMMode();
+  });
+
+  test("all MML elements can be created from a registered VirtualDocument", () => {
+    MElement.resetToVirtualMode();
+    const doc = new VirtualDocument();
+    registerCustomElementsToVirtualDocument(doc);
+
+    for (const Element of MML_ELEMENTS) {
+      const el = doc.createElement(Element.tagName);
+      expect(el.tagName).toBe(Element.tagName.toUpperCase());
+    }
+  });
+});


### PR DESCRIPTION
Fix cross-realm dispatchEvent failure when MML elements are registered in an iframe by storing the target window reference in overwriteSuperclass and using its CustomEvent constructor, instead of relying on instanceof Element (which fails across iframe boundaries) and the main window's CustomEvent (which is rejected by the iframe's native dispatchEvent).

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
