### PR TITLE
Vitest aliases, fix test file URLs, and add Pointer/RFC6902 tests

### DIFF
--- a/packages/mml-cli/vitest.config.ts
+++ b/packages/mml-cli/vitest.config.ts
@@ -1,6 +1,22 @@
+import path from "node:path";
+
 import { defineConfig } from "vitest/config";
 
+const repoRoot = path.resolve(__dirname, "../..");
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@mml-io/networked-dom-document": path.resolve(
+        repoRoot,
+        "packages/networked-dom-document/src/index.ts",
+      ),
+      "@mml-io/networked-dom-server": path.resolve(repoRoot, "packages/networked-dom-server/src/index.ts"),
+      "@mml-io/mml-schema-validator": path.resolve(repoRoot, "packages/schema-validator/src/index.ts"),
+      "@mml-io/mml-web-client": path.resolve(repoRoot, "packages/mml-web-client/src/index.ts"),
+      "@mml-io/observable-dom": path.resolve(repoRoot, "packages/observable-dom/src/index.ts"),
+    },
+  },
   test: {
     globals: true,
     environment: "node",

--- a/packages/networked-dom-document/src/rfc6902/test/patch.test.ts
+++ b/packages/networked-dom-document/src/rfc6902/test/patch.test.ts
@@ -58,4 +58,68 @@ describe("patch", () => {
     expect(user).toEqual({ id: "chbrown" }); // should change nothing
     expect(results.map(resultName)).toEqual(["MissingError"]); // should result in MissingError
   });
+
+  test("add to arrays and objects", () => {
+    const payload = { users: [{ id: "a" }] };
+    const results = applyPatch(payload, [
+      { op: "add", path: "/users/1", value: { id: "b" } },
+      { op: "add", path: "/users/-", value: { id: "c" } },
+      { op: "add", path: "/group", value: "dev" },
+    ]);
+
+    expect(payload).toEqual({ users: [{ id: "a" }, { id: "b" }, { id: "c" }], group: "dev" });
+    expect(results.map(resultName)).toEqual([null, null, null]);
+  });
+
+  test("remove from arrays and objects", () => {
+    const payload = { users: [{ id: "a" }, { id: "b" }], group: "dev" };
+    const results = applyPatch(payload, [
+      { op: "remove", path: "/users/0" },
+      { op: "remove", path: "/group" },
+    ]);
+
+    expect(payload).toEqual({ users: [{ id: "b" }] });
+    expect(results.map(resultName)).toEqual([null, null]);
+  });
+
+  test("replace supports object and array targets", () => {
+    const payload = { users: [{ id: "a" }], group: "dev" };
+    const results = applyPatch(payload, [
+      { op: "replace", path: "/users/0", value: { id: "b" } },
+      { op: "replace", path: "/group", value: "ops" },
+    ]);
+
+    expect(payload).toEqual({ users: [{ id: "b" }], group: "ops" });
+    expect(results.map(resultName)).toEqual([null, null]);
+  });
+
+  test("move and copy support nested values and clone semantics", () => {
+    const payload = { source: { nested: { value: 1 } }, target: {}, copied: {} as { nested?: { value: number } } };
+    const results = applyPatch(payload, [
+      { op: "move", from: "/source/nested", path: "/target/nested" },
+      { op: "copy", from: "/target/nested", path: "/copied/nested" },
+    ]);
+
+    expect(results.map(resultName)).toEqual([null, null]);
+    expect(payload).toEqual({
+      source: {},
+      target: { nested: { value: 1 } },
+      copied: { nested: { value: 1 } },
+    });
+
+    payload.target.nested.value = 2;
+    expect(payload.copied.nested?.value).toBe(1);
+  });
+
+  test("test operation and invalid operations return expected errors", () => {
+    const payload = { id: "chbrown" };
+    const results = applyPatch(payload, [
+      { op: "test", path: "/id", value: "chbrown" },
+      { op: "test", path: "/id", value: "different" },
+      { op: "invalid", path: "/id" } as any,
+    ]);
+
+    expect(payload).toEqual({ id: "chbrown" });
+    expect(results.map(resultName)).toEqual([null, "TestError", "InvalidOperationError"]);
+  });
 });

--- a/packages/networked-dom-document/src/rfc6902/test/pointer.test.ts
+++ b/packages/networked-dom-document/src/rfc6902/test/pointer.test.ts
@@ -41,4 +41,48 @@ describe("Pointer", () => {
     Pointer.fromJSON("/obj/c").set(input, "C");
     expect(input.obj.c).toEqual("C"); // should add object value in-place
   });
+
+  test("root pointer evaluates and stringifies correctly", () => {
+    const pointer = Pointer.fromJSON("");
+    expect(pointer.toString()).toBe("");
+    expect(pointer.evaluate(example)).toEqual({ parent: null, key: "", value: example });
+  });
+
+  test("throws for invalid pointer path missing root slash", () => {
+    expect(() => Pointer.fromJSON("arr/1")).toThrow("Invalid JSON Pointer: arr/1");
+  });
+
+  test("escapes and unescapes tokens in toString / fromJSON", () => {
+    const input = { "a/b": { "~key": 123 } };
+    const pointer = Pointer.fromJSON("/a~1b/~0key");
+    expect(pointer.get(input)).toBe(123);
+    expect(pointer.toString()).toBe("/a~1b/~0key");
+  });
+
+  test("evaluate ignores prototype poisoning tokens", () => {
+    const input = { safe: true } as any;
+    const protoPointer = Pointer.fromJSON("/__proto__/polluted");
+    const result = protoPointer.evaluate(input);
+
+    expect(result.parent).toEqual(input);
+    expect(result.key).toBe("polluted");
+    expect(result.value).toBeUndefined();
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  test("set no-ops when intermediate path does not exist", () => {
+    const input: any = { obj: undefined };
+    Pointer.fromJSON("/obj/missing").set(input, "value");
+    expect(input).toEqual({ obj: undefined });
+  });
+
+  test("push and add behave as mutable vs immutable operations", () => {
+    const base = new Pointer([""]);
+    base.push("obj");
+    expect(base.toString()).toBe("/obj");
+
+    const extended = base.add("a/b");
+    expect(base.toString()).toBe("/obj");
+    expect(extended.toString()).toBe("/obj/a~1b");
+  });
 });

--- a/packages/networked-dom-document/test/networked-dom-v01/end-to-end.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v01/end-to-end.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 
 describe("end to end - v0.1", () => {
   test("client snapshot and diff on reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load("<m-cube></m-cube>");
 
@@ -74,7 +74,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("client snapshot and larger diff on reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load("<m-cube></m-cube>");
 
@@ -161,7 +161,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("client sends event and observes state change", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube id="clickable-cube" color="red"></m-cube>
@@ -228,7 +228,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("simple nested removal", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -316,7 +316,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("simple nested re-addition", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -423,7 +423,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("appending child element to ancestor", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -554,7 +554,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("multiple element additions", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -702,7 +702,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("multiple element creations with removal of previous sibling", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-group id="holder">
@@ -829,7 +829,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("multiple element additions after removal", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -958,7 +958,7 @@ describe("end to end - v0.1", () => {
   });
 
   test("child addition", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <script>
@@ -1056,7 +1056,7 @@ setTimeout(() => {
   });
 
   test("element insertion ordering", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -1272,7 +1272,7 @@ setTimeout(() => {
   });
 
   test("multiple element attribute changes observation", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <script>
@@ -1331,7 +1331,7 @@ setTimeout(() => {
     /* This test checks that regardless of the order of attribute changes still
         results in an eventually-consistent client view.
      */
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <script>

--- a/packages/networked-dom-document/test/networked-dom-v01/filtering.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v01/filtering.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 
 describe("filtering - v0.1", () => {
   test("filters onclick on reloads", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube onclick="alert('in-first')" color="red"></m-cube>
@@ -87,7 +87,7 @@ describe("filtering - v0.1", () => {
   });
 
   test("filters onclick on mutation", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube onclick="this.setAttribute('onclick','doSomething()');" color="red"></m-cube>

--- a/packages/networked-dom-document/test/networked-dom-v01/multi-client-subjectivity.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v01/multi-client-subjectivity.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 
 describe("multi-client subjectivity - v0.1", () => {
   test("multi-client subjectivity on load - visible-to", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `
@@ -184,7 +184,7 @@ describe("multi-client subjectivity - v0.1", () => {
   });
 
   test("multi-client subjectivity on load - hidden-from", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `
@@ -354,7 +354,7 @@ describe("multi-client subjectivity - v0.1", () => {
   });
 
   test("multi-client subjectivity with reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `
@@ -522,7 +522,7 @@ describe("multi-client subjectivity - v0.1", () => {
   });
 
   test("multi-client subjectivity with reload and change connections", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `

--- a/packages/networked-dom-document/test/networked-dom-v01/regression.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v01/regression.test.ts
@@ -18,7 +18,7 @@ describe("regression tests - v0.1", () => {
    This is a test added to fix an issue discovered with remapping ids on
    reload and is kept as a regression test.
   */
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `<m-plane id="plane"></m-plane>
@@ -264,7 +264,7 @@ describe("regression tests - v0.1", () => {
   });
 
   test("visible-to toggle does not duplicate children", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube id="open-cube"></m-cube>

--- a/packages/networked-dom-document/test/networked-dom-v01/reload.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v01/reload.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 
 describe("reloading - v0.1", () => {
   test("add-within-group-on-reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red"></m-cube>
@@ -176,7 +176,7 @@ describe("reloading - v0.1", () => {
   });
 
   test("move-to-within-group-on-reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-plane color="blue" width="20" height="20" rx="-90"></m-plane>
@@ -356,7 +356,7 @@ describe("reloading - v0.1", () => {
   });
 
   test("remapping-on-reload-and-click", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `
@@ -528,7 +528,7 @@ describe("reloading - v0.1", () => {
   });
 
   test("should not send hidden elements on reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-group id="one" visible-to="0">

--- a/packages/networked-dom-document/test/networked-dom-v02/connected-event-token.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/connected-event-token.test.ts
@@ -19,7 +19,7 @@ describe("connected event token field - v0.2", () => {
     const loggedMessages: Array<LogMessage> = [];
 
     const doc = new EditableNetworkedDOM(
-      "file://test.html",
+      "file:///test.html",
       LocalObservableDOMFactory,
       true,
       (logMessage: LogMessage) => {
@@ -83,7 +83,7 @@ describe("connected event token field - v0.2", () => {
     const loggedMessages: Array<LogMessage> = [];
 
     const doc = new EditableNetworkedDOM(
-      "file://test.html",
+      "file:///test.html",
       LocalObservableDOMFactory,
       true,
       (logMessage: LogMessage) => {
@@ -147,7 +147,7 @@ describe("connected event token field - v0.2", () => {
     const loggedMessages: Array<LogMessage> = [];
 
     const doc = new EditableNetworkedDOM(
-      "file://test.html",
+      "file:///test.html",
       LocalObservableDOMFactory,
       true,
       (logMessage: LogMessage) => {
@@ -258,7 +258,7 @@ describe("connected event token field - v0.2", () => {
     const loggedMessages: Array<LogMessage> = [];
 
     const doc = new EditableNetworkedDOM(
-      "file://test.html",
+      "file:///test.html",
       LocalObservableDOMFactory,
       true,
       (logMessage: LogMessage) => {
@@ -326,7 +326,7 @@ describe("connected event token field - v0.2", () => {
     const loggedMessages: Array<LogMessage> = [];
 
     const doc = new EditableNetworkedDOM(
-      "file://test.html",
+      "file:///test.html",
       LocalObservableDOMFactory,
       true,
       (logMessage: LogMessage) => {

--- a/packages/networked-dom-document/test/networked-dom-v02/end-to-end.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/end-to-end.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 
 describe("end to end - v0.2", () => {
   test("client snapshot and diff on reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load("<m-cube></m-cube>");
 
@@ -69,7 +69,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("client snapshot and larger diff on reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load("<m-cube></m-cube>");
 
@@ -147,7 +147,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("client sends event and observes state change", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube id="clickable-cube" color="red"></m-cube>
@@ -224,7 +224,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("simple nested removal", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -310,7 +310,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("simple nested re-addition", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -420,7 +420,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("appending child element to ancestor", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -553,7 +553,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("multiple element additions", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -701,7 +701,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("multiple element creations with removal of previous sibling", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-group id="holder">
@@ -830,7 +830,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("multiple element additions after removal", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -960,7 +960,7 @@ describe("end to end - v0.2", () => {
   });
 
   test("child addition", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <script>
@@ -1054,7 +1054,7 @@ setTimeout(() => {
   });
 
   test("element insertion ordering", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red" z="2" id="c1">
@@ -1267,7 +1267,7 @@ setTimeout(() => {
   });
 
   test("multiple element attribute changes observation", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <script>
@@ -1326,7 +1326,7 @@ setTimeout(() => {
     /* This test checks that regardless of the order of attribute changes still
         results in an eventually-consistent client view.
      */
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <script>

--- a/packages/networked-dom-document/test/networked-dom-v02/filtering.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/filtering.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 
 describe("filtering - v0.2", () => {
   test("filters onclick on reloads", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube onclick="alert('in-first')" color="red"></m-cube>
@@ -81,7 +81,7 @@ describe("filtering - v0.2", () => {
   });
 
   test("filters onclick on mutation", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube onclick="this.setAttribute('onclick','doSomething()');" color="red"></m-cube>

--- a/packages/networked-dom-document/test/networked-dom-v02/multi-client-subjectivity.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/multi-client-subjectivity.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 
 describe("multi-client subjectivity - v0.2", () => {
   test("multi-client subjectivity on load - visible-to", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
 
     const clientOneWs = new MockWebsocketV02();
@@ -196,7 +196,7 @@ describe("multi-client subjectivity - v0.2", () => {
   });
 
   test("multi-client subjectivity on load - hidden-from", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
 
     const clientOneWs = new MockWebsocketV02();
@@ -375,7 +375,7 @@ describe("multi-client subjectivity - v0.2", () => {
   });
 
   test("multi-client subjectivity with reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `
@@ -540,7 +540,7 @@ describe("multi-client subjectivity - v0.2", () => {
   });
 
   test("multi-client subjectivity with reload and change connections", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `
@@ -759,7 +759,7 @@ describe("multi-client subjectivity - v0.2", () => {
   });
 
   test("visibility changes on disconnect", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
 
     const clientOneWs = new MockWebsocketV02();

--- a/packages/networked-dom-document/test/networked-dom-v02/regression.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/regression.test.ts
@@ -23,7 +23,7 @@ describe("regression tests - v0.2", () => {
    This is a test added to fix an issue discovered with remapping ids on
    reload and is kept as a regression test.
   */
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `<m-plane id="plane"></m-plane>
@@ -257,7 +257,7 @@ describe("regression tests - v0.2", () => {
   });
 
   test("visible-to toggle does not duplicate children", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube id="open-cube"></m-cube>
@@ -387,7 +387,7 @@ openCube.addEventListener("click", () => {
      * the same synchronous handler). This is the pattern from the original
      * m-overlay-hierarchy-test.html crash.
      */
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube id="grandparent">
@@ -447,7 +447,7 @@ openCube.addEventListener("click", () => {
      * When a parent is removed before its children are individually removed,
      * mutations for the children reference already-deleted parents.
      */
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube id="container">
@@ -610,7 +610,7 @@ openCube.addEventListener("click", () => {
       return observableDOM;
     };
 
-    const doc = new EditableNetworkedDOM("file://test.html", mockFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", mockFactory);
     currentDoc = doc;
     doc.load("<!-- mock -->");
 

--- a/packages/networked-dom-document/test/networked-dom-v02/reload.test.ts
+++ b/packages/networked-dom-document/test/networked-dom-v02/reload.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 
 describe("reloading - v0.2", () => {
   test("add-within-group-on-reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-cube color="red"></m-cube>
@@ -151,7 +151,7 @@ describe("reloading - v0.2", () => {
   });
 
   test("move-to-within-group-on-reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-plane color="blue" width="20" height="20" rx="-90"></m-plane>
@@ -317,7 +317,7 @@ describe("reloading - v0.2", () => {
   });
 
   test("remapping-on-reload-and-click", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(
       `
@@ -481,7 +481,7 @@ describe("reloading - v0.2", () => {
   });
 
   test("should not send hidden elements on reload", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory);
     currentDoc = doc;
     doc.load(`
 <m-group id="one" visible-to="0">
@@ -587,7 +587,7 @@ describe("reloading - v0.2", () => {
   });
 
   test("svg elements with self-closing tags", async () => {
-    const doc = new EditableNetworkedDOM("file://test.html", LocalObservableDOMFactory, false);
+    const doc = new EditableNetworkedDOM("file:///test.html", LocalObservableDOMFactory, false);
     currentDoc = doc;
     doc.load(`
 <m-overlay anchor="center">

--- a/packages/networked-dom-document/vitest.config.ts
+++ b/packages/networked-dom-document/vitest.config.ts
@@ -1,6 +1,25 @@
+import path from "node:path";
+
 import { defineConfig } from "vitest/config";
 
+const repoRoot = path.resolve(__dirname, "../..");
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@mml-io/networked-dom-server": path.resolve(repoRoot, "packages/networked-dom-server/src/index.ts"),
+      "@mml-io/networked-dom-document": path.resolve(repoRoot, "packages/networked-dom-document/src/index.ts"),
+      "@mml-io/observable-dom-common": path.resolve(
+        repoRoot,
+        "packages/observable-dom-common/src/index.ts",
+      ),
+      "@mml-io/observable-dom": path.resolve(repoRoot, "packages/observable-dom/src/index.ts"),
+      "@mml-io/networked-dom-protocol": path.resolve(
+        repoRoot,
+        "packages/networked-dom-protocol/src/index.ts",
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: "node",


### PR DESCRIPTION
### Motivation
- Ensure in-repo packages resolve correctly when running Vitest by adding explicit path aliases to the test configs.
- Correct test fixtures that use file URLs so they use a proper `file:///` URL form expected by the code.
- Improve coverage for JSON Pointer and RFC6902 patch handling by adding unit tests that exercise arrays, objects, cloning semantics and error cases.

### Description
- Added `resolve.alias` entries to `vitest.config.ts` in `packages/mml-cli` and `packages/networked-dom-document` using `node:path` to map internal package names to their `src/index.ts` files for correct module resolution in tests.
- Replaced `"file://test.html"` with `"file:///test.html"` across numerous test files to use a canonical file URL form.
- Expanded tests in `networked-dom-document` including new cases in `rfc6902/patch.test.ts` (add/remove/replace/move/copy/test/invalid ops) and `rfc6902/pointer.test.ts` (root pointer, invalid pointers, escaping, prototype poisoning, no-op set, push/add semantics), and updated various e2e and v0.1/v0.2 tests to use the corrected file URL.

### Testing
- Ran the repository test suite via Vitest across packages (run via the monorepo test command), including the newly added pointer and RFC6902 tests, and they completed successfully.
- Coverage configuration remains unchanged and continues to produce `lcov` reports in the `coverage` directories.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1c656b7748320ad391d6a04b8ba42)